### PR TITLE
UI — Migrate Projects list to Angular Material list components

### DIFF
--- a/frontend/src/app/pages/projects/projects.html
+++ b/frontend/src/app/pages/projects/projects.html
@@ -13,20 +13,31 @@
 <p class="error">{{ error }}</p>
 }
 
-<ul>
-  @for (project of projects; track project.id) {
-  <li>
-    <button matIconButton class="edit-project-btn" (click)="openEditProjectDialog(project)">
-      <mat-icon>edit</mat-icon>
-    </button>
-    <button matIconButton class="show-project-btn" (click)="showProjectDetail(project.id)">
-      <mat-icon>visibility</mat-icon>
-    </button>
-    <button matIconButton class="show-project-btn" (click)="openDeleteProjectConfirmDialog(project)">
-      <mat-icon>delete_forever</mat-icon>
-    </button>
-    <strong>{{ project.name }}</strong>
-    <div>{{ project.description }}</div>
-  </li>
+<mat-list>
+  @for (project of projects; track project.id; let odd = $odd; let last = $last) {
+  <mat-list-item [class.alt-row]="odd">
+    <span matListItemTitle>{{ project.name }}</span>
+    <span matListItemLine>{{ project.description }}</span>
+
+    <span matListItemMeta>
+      <button mat-icon-button class="edit-project-btn" (click)="openEditProjectDialog(project)"
+        aria-label="Edit project">
+        <mat-icon>edit</mat-icon>
+      </button>
+
+      <button mat-icon-button class="show-project-btn" (click)="showProjectDetail(project.id)"
+        aria-label="Open project">
+        <mat-icon>visibility</mat-icon>
+      </button>
+
+      <button mat-icon-button class="delete-project-btn" (click)="openDeleteProjectConfirmDialog(project)"
+        aria-label="Delete project">
+        <mat-icon>delete_forever</mat-icon>
+      </button>
+    </span>
+  </mat-list-item>
+    @if (!last) {
+    <mat-divider></mat-divider>
+    }
   }
-</ul>
+</mat-list>

--- a/frontend/src/app/pages/projects/projects.scss
+++ b/frontend/src/app/pages/projects/projects.scss
@@ -1,0 +1,3 @@
+mat-list-item.alt-row {
+  background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.02));
+}

--- a/frontend/src/app/pages/projects/projects.ts
+++ b/frontend/src/app/pages/projects/projects.ts
@@ -12,11 +12,13 @@ import { ProjectDialog } from './project-dialog';
 import { ProjectDialogData, ProjectDialogResult } from './project-dialog.types';
 import { ConfirmDialog } from '../../shared/dialogs/confirm-dialog';
 import { ConfirmDialogData } from '../../shared/dialogs/confirm-dialog.types';
+import { MatListModule } from '@angular/material/list';
+import { MatDividerModule } from '@angular/material/divider';
 
 @Component({
   selector: 'app-projects',
   standalone: true,
-  imports: [MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule],
+  imports: [MatListModule, MatDividerModule, MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule],
   templateUrl: './projects.html',
   styleUrl: './projects.scss',
 })


### PR DESCRIPTION
Fixes #33 

- Migrated Projects list from `ul/li` to `mat-list` / `mat-list-item`
- Used Material-provided layout slots for:
  - title
  - description
  - actions (edit / open / delete)
- Added light visual separation between items:
  - `mat-divider`
  - very subtle alternating background for readability
- Preserved all existing behaviors and interactions
