### PR TITLE
UI — Improve Project detail page layout and spacing

### DIFF
--- a/frontend/src/app/pages/project-detail/project-detail.html
+++ b/frontend/src/app/pages/project-detail/project-detail.html
@@ -1,68 +1,99 @@
-@if (loadingProject) {
-<p>Loading project…</p>
-}
 
-@if (errorProject) {
-<p class="error">{{ errorProject }}</p>
-}
+<section class="page">
 
-<h2>{{ project?.name }} project detail</h2>
-<p>{{ project?.description }}</p>
-
-
-<button matButton="outlined" color="primary" (click)="openAddNewTaskDialog()">
-  <mat-icon>add</mat-icon>
-  Add new task
-</button>
-
-<h3>Tasks</h3>
-
-@if (loadingTasks) {
-<p>Loading tasks…</p>
-}
-
-@if (errorTasks) {
-<p class="error">{{ errorTasks }}</p>
-}
-
-<mat-list>
-  @for (task of tasks; track task.id; let odd = $odd; let last = $last) {
-    <mat-list-item [class.alt-row]="odd">
-      <span matListItemTitle>{{ task.title }}</span>
-
-      @if (task.description) {
-        <span matListItemLine>{{ task.description }}</span>
-      }
-
-      <span matListItemLine class="task-subline">
-        Due: {{ task.dueDate | date }}
-      </span>
-
-      <span matListItemMeta class="task-meta-right">
-        <button
-          matButton="tonal"
-          class="status-btn"
-          (click)="onStatusClick(task)"
-          [disabled]="updatingTaskId === task.id"
-        >
-          <span class="status-emoji">{{ statusEmoji(task.status) }}</span>
-          <span class="status-label">{{ statusLabel(task.status) }}</span>
-        </button>
-
-        <span class="task-actions">
-          <button matIconButton class="edit-task-btn" (click)="openEditTaskDialog(task)" aria-label="Edit task">
-            <mat-icon>edit</mat-icon>
-          </button>
-
-          <button matIconButton class="delete-task-btn" (click)="openDeleteTaskConfirmDialog(task)" aria-label="Delete task">
-            <mat-icon>delete_forever</mat-icon>
-          </button>
-        </span>
-      </span>
-    </mat-list-item>
-
-    @if (!last) {
-      <mat-divider></mat-divider>
+  <div class="page-status">
+    @if (loadingProject) {
+      <mat-card class="status-card status-info">
+        <mat-card-content>
+          Loading project…
+        </mat-card-content>
+      </mat-card>
     }
-  }
-</mat-list>
+
+    @if (errorProject) {
+      <mat-card class="status-card status-error">
+        <mat-card-content>
+          {{ errorProject }}
+        </mat-card-content>
+      </mat-card>
+    }
+
+    @if (loadingTasks) {
+      <mat-card class="status-card status-info">
+        <mat-card-content>
+          Loading tasks…
+        </mat-card-content>
+      </mat-card>
+    }
+
+    @if (errorTasks) {
+      <mat-card class="status-card status-error">
+        <mat-card-content>
+          {{ errorTasks }}
+        </mat-card-content>
+      </mat-card>
+    }
+  </div>
+
+  <mat-card class="example-card" appearance="outlined">
+    <mat-card-header>
+      <mat-card-title>{{ project?.name }} project detail</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p>{{ project?.description }}</p>
+    </mat-card-content>
+  </mat-card>
+
+  <header class="page-header">
+    <h2>Tasks</h2>
+  </header>
+
+  <div class="page-actions">
+    <button matButton="outlined" color="primary" (click)="openAddNewTaskDialog()">
+      <mat-icon>add</mat-icon>
+      Add new task
+    </button>
+  </div>
+
+  <mat-list>
+    @for (task of tasks; track task.id; let odd = $odd; let last = $last) {
+      <mat-list-item [class.alt-row]="odd">
+        <span matListItemTitle>{{ task.title }}</span>
+
+        @if (task.description) {
+          <span matListItemLine>{{ task.description }}</span>
+        }
+
+        <span matListItemLine class="task-subline">
+          Due: {{ task.dueDate | date }}
+        </span>
+
+        <span matListItemMeta class="task-meta-right">
+          <button
+            matButton="tonal"
+            class="status-btn"
+            (click)="onStatusClick(task)"
+            [disabled]="updatingTaskId === task.id"
+          >
+            <span class="status-emoji">{{ statusEmoji(task.status) }}</span>
+            <span class="status-label">{{ statusLabel(task.status) }}</span>
+          </button>
+
+          <span class="task-actions">
+            <button matIconButton class="edit-task-btn" (click)="openEditTaskDialog(task)" aria-label="Edit task">
+              <mat-icon>edit</mat-icon>
+            </button>
+
+            <button matIconButton class="delete-task-btn" (click)="openDeleteTaskConfirmDialog(task)" aria-label="Delete task">
+              <mat-icon>delete_forever</mat-icon>
+            </button>
+          </span>
+        </span>
+      </mat-list-item>
+
+      @if (!last) {
+        <mat-divider></mat-divider>
+      }
+    }
+  </mat-list>
+</section>

--- a/frontend/src/app/pages/project-detail/project-detail.scss
+++ b/frontend/src/app/pages/project-detail/project-detail.scss
@@ -1,5 +1,44 @@
+.page {
+  display: block;
+  padding: 16px;
+}
+
+.page-header {
+  margin-bottom: 8px;
+}
+
+.page-status {
+  margin-bottom: 20px;
+}
+
+.page-actions {
+  margin-bottom: 0;
+}
+
+.page-content {
+  display: block;
+}
+
 mat-list-item.alt-row {
   background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.02));
+}
+
+.status-card {
+  margin: 0 0 8px 0;
+  padding: 0;
+}
+
+.status-card mat-card-content {
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.status-error {
+  background-color: rgba(244, 67, 54, 0.08);
+}
+
+.status-info {
+  background-color: rgba(33, 150, 243, 0.08);
 }
 
 .status-btn {

--- a/frontend/src/app/pages/project-detail/project-detail.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.ts
@@ -15,11 +15,12 @@ import { TaskDialogData, TaskDialogResult } from './task-dialog.types';
 import { ConfirmDialog } from '../../shared/dialogs/confirm-dialog';
 import { ConfirmDialogData } from '../../shared/dialogs/confirm-dialog.types';
 import { MatListModule } from '@angular/material/list';
+import { MatCardModule } from '@angular/material/card';
 
 @Component({
   selector: 'app-project-detail',
   standalone: true,
-  imports: [DatePipe, MatListModule, MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule],
+  imports: [DatePipe, MatListModule, MatCardModule, MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule],
   templateUrl: './project-detail.html',
   styleUrl: './project-detail.scss',
 })


### PR DESCRIPTION
Fixes #37 

- Introduced a clearer page structure:
  - Project overview section (Material card)
  - Tasks section (title, action, list)
- Improved spacing between sections using local styles
- Standardized status messages (loading / error) using Material components
- Kept existing task behaviors and interactions unchanged
