### PR TITLE
Make app toolbar responsive on mobile and tablet

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,17 +1,18 @@
-<mat-toolbar color="primary">
-  <h1>{{ title() }}</h1>
+<mat-toolbar color="primary" class="app-toolbar">
+  <h1 class="app-toolbar__title">{{ title() }}</h1>
 
-  <span style="flex: 1 1 auto"></span>
 
-  @if (auth.isLoggedIn()) {
-  <a mat-button routerLink="/projects" routerLinkActive="active-link">
-    Projects
-  </a>
-  }
+  <div class="app-toolbar__actions">
+    @if (auth.isLoggedIn()) {
+    <a mat-button routerLink="/projects" routerLinkActive="active-link">
+      Projects
+    </a>
+    }
 
-  <button matButton="outlined" (click)="onAuthAction()">
-    {{ auth.isLoggedIn() ? 'Logout' : 'Login' }}
-  </button>
+    <button matButton="outlined" (click)="onAuthAction()">
+      {{ auth.isLoggedIn() ? 'Logout' : 'Login' }}
+    </button>
+  </div>
 </mat-toolbar>
 
 <div class="app-container">

--- a/frontend/src/app/app.scss
+++ b/frontend/src/app/app.scss
@@ -6,3 +6,46 @@
   font-weight: 600;
   text-decoration: underline;
 }
+
+/* Toolbar */
+.app-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-toolbar__title {
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-toolbar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.app-toolbar__spacer {
+  flex: 1 1 auto;
+}
+
+/* Handset */
+@media (max-width: 600px) {
+  .app-toolbar {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .app-toolbar__title {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  .app-toolbar__actions {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
Fixes #43

- Enabled layout reflow on small screens using flex wrap
- Ensured long titles truncate safely with ellipsis
- Stacked toolbar actions below the title on handset widths
- Centered the title only on handset breakpoint
- Preserved the existing desktop appearance