### PR TITLE
Add devlan environment for LAN/mobile development

### DIFF
--- a/backend/src/main/resources/application-docker.yaml
+++ b/backend/src/main/resources/application-docker.yaml
@@ -19,4 +19,5 @@ app:
   cors:
     allowed-origins:
       - "http://localhost:4200"
+      - "http://192.168.1.90:4200"
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -59,6 +59,17 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "devlan": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.devlan.ts"
+                }
+              ],
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
             }
           },
           "defaultConfiguration": "production"
@@ -71,6 +82,9 @@
             },
             "development": {
               "buildTarget": "frontend:build:development"
+            },
+            "devlan": {
+              "buildTarget": "frontend:build:devlan"
             }
           },
           "defaultConfiguration": "development"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:devlan": "ng serve --configuration devlan --host 0.0.0.0 --port 4200",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -3,6 +3,11 @@ import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/rou
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { Auth } from './services/auth';
+import { environment } from '../environments/environment';
+
+if (!environment.production) {
+  console.info('[DEV] API base URL:', environment.apiBaseUrl);
+}
 
 @Component({
   selector: 'app-root',

--- a/frontend/src/environments/environment.devlan.ts
+++ b/frontend/src/environments/environment.devlan.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://192.168.1.90:8080',
+};


### PR DESCRIPTION
This PR adds a dedicated "devlan" Angular environment and npm script to support local LAN-based development
(e.g. testing the application on a smartphone) with a prod-like setup.

No functional changes to the application itself.