### PR TITLE
fix initial focus and remove CDK focus warning

### DIFF
--- a/frontend/src/app/pages/project-detail/task-dialog.html
+++ b/frontend/src/app/pages/project-detail/task-dialog.html
@@ -11,7 +11,7 @@
   <mat-dialog-content class="dialog-content">
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Title</mat-label>
-      <input matInput formControlName="title" />
+      <input matInput formControlName="title" cdkFocusInitial/>
       @if (submitAttempted && form.controls.title.invalid) {
         <mat-error>Title is required.</mat-error>
       }
@@ -45,7 +45,7 @@
 
   <mat-dialog-actions>
     <button mat-button type="button" (click)="clickOnCancel()">Cancel</button>
-    <button mat-button type="submit" [disabled]="form.invalid" cdkFocusInitial>
+    <button mat-button type="submit" [disabled]="form.invalid">
       {{ primaryButtonLabel }}
     </button>
   </mat-dialog-actions>

--- a/frontend/src/app/pages/projects/project-dialog.html
+++ b/frontend/src/app/pages/projects/project-dialog.html
@@ -11,7 +11,7 @@
 
     <mat-form-field class="full-width">
       <mat-label>Project name</mat-label>
-      <input matInput formControlName="name"/>
+      <input matInput formControlName="name" cdkFocusInitial/>
       @if (submitAttempted && form.controls.name.invalid) {
         <mat-error>Name is required.</mat-error>
       }


### PR DESCRIPTION
Fixes #59 

This PR improves initial focus handling in dialogs to ensure proper keyboard and accessibility behavior.

Changes:
- Removed cdkFocusInitial from submit buttons that can be disabled
- Applied initial focus to the first meaningful input field
- Fixed Angular CDK warning when opening dialogs in create mode

This aligns dialog UX with expected behavior and avoids unnecessary focus-related warnings, without adding extra complexity.
