### PR TITLE
Define i18n UI text strategy (keys + structure)

### DIFF
--- a/frontend/src/app/shared/i18n/README.md
+++ b/frontend/src/app/shared/i18n/README.md
@@ -1,0 +1,141 @@
+# 🌍 UI Text / i18n-ready strategy
+
+This project uses a lightweight, dependency-free UI text system to prepare the Angular UI for future internationalization.
+
+No external i18n library is used yet.
+
+---
+
+## 📌 Where UI texts live
+
+All UI strings are centralized under:
+
+frontend/src/app/shared/i18n/
+
+English is the current default language:
+
+frontend/src/app/shared/i18n/en/
+
+Texts are split by feature:
+
+- app.ts
+- auth.ts
+- projects.ts
+- tasks.ts
+- shared.ts
+
+Each file exports a dictionary:
+
+- APP_EN
+- AUTH_EN
+- PROJECTS_EN
+- TASKS_EN
+- SHARED_EN
+
+They are merged into a single dictionary:
+
+- EN_DICTIONARY
+
+---
+
+## 🔑 Key naming conventions
+
+Keys use dot notation:
+
+feature.category.name
+
+Allowed feature prefixes:
+
+- app.*
+- auth.*
+- projects.*
+- tasks.*
+- shared.*
+
+Examples:
+
+- auth.login.validation.emailRequired
+- projects.message.created
+- tasks.confirmDelete.title
+- shared.action.cancel
+
+Generic actions must be reused from shared:
+
+- shared.action.cancel
+- shared.action.save
+- shared.action.delete
+- shared.action.ok
+
+---
+
+## 🧩 Interpolation (dynamic texts)
+
+Named placeholders are supported:
+
+Delete project "{projectName}"
+
+Usage:
+
+translate.t('projects.confirmDelete.title', {
+  projectName: project.name,
+});
+
+Missing params keep the placeholder visible.
+
+---
+
+## 🛠️ How to use in templates
+
+Use the standalone pipe:
+
+{{ 'shared.action.cancel' | translate }}
+
+---
+
+## 🛠️ How to use in TypeScript
+
+Inject the service:
+
+private readonly translate = inject(UiTextService);
+
+Then call:
+
+this.translate.t('projects.message.created');
+
+---
+
+## ➕ Adding a new key
+
+1. Add the key/value to the correct feature file in en/
+2. Reuse shared keys whenever possible
+3. Run tests to ensure:
+   - no duplicate keys
+   - valid key format
+   - non-empty values
+
+---
+
+## ➕ Adding a new language (example: French)
+
+1. Create folder:
+
+frontend/src/app/shared/i18n/fr/
+
+2. Add feature files:
+
+app.ts, auth.ts, projects.ts, tasks.ts, shared.ts
+
+3. Create fr/index.ts exporting FR_DICTIONARY
+
+4. Register it in:
+
+frontend/src/app/shared/i18n/index.ts
+
+Then UI_DICTIONARIES becomes:
+
+{
+  en: EN_DICTIONARY,
+  fr: FR_DICTIONARY
+}
+
+No lazy-loading is implemented yet (languages are bundled at build time).

--- a/frontend/src/app/shared/i18n/en/app.ts
+++ b/frontend/src/app/shared/i18n/en/app.ts
@@ -1,0 +1,8 @@
+import type { UiDictionary } from './index';
+
+export const APP_EN: UiDictionary = {
+  'app.title': 'Project Management App',
+  'app.nav.projects': 'Projects',
+  'app.nav.login': 'Login',
+  'app.nav.logout': 'Logout',
+};

--- a/frontend/src/app/shared/i18n/en/auth.ts
+++ b/frontend/src/app/shared/i18n/en/auth.ts
@@ -1,0 +1,13 @@
+import type { UiDictionary } from './index';
+
+export const AUTH_EN: UiDictionary = {
+  'auth.login.title': 'Login',
+  'auth.login.label.email': 'Email',
+  'auth.login.label.password': 'Password',
+
+  'auth.login.validation.emailRequired': 'Email is required.',
+  'auth.login.validation.emailInvalid': 'Please enter a valid email address.',
+  'auth.login.validation.passwordRequired': 'Password is required.',
+
+  'auth.login.error.invalidCredentials': 'Invalid credentials',
+};

--- a/frontend/src/app/shared/i18n/en/index.ts
+++ b/frontend/src/app/shared/i18n/en/index.ts
@@ -1,0 +1,15 @@
+import { APP_EN } from './app';
+import { AUTH_EN } from './auth';
+import { PROJECTS_EN } from './projects';
+import { TASKS_EN } from './tasks';
+import { SHARED_EN } from './shared';
+
+export type UiDictionary = Record<string, string>;
+
+export const EN_DICTIONARY: UiDictionary = {
+  ...APP_EN,
+  ...AUTH_EN,
+  ...PROJECTS_EN,
+  ...TASKS_EN,
+  ...SHARED_EN,
+};

--- a/frontend/src/app/shared/i18n/en/projects.ts
+++ b/frontend/src/app/shared/i18n/en/projects.ts
@@ -1,0 +1,42 @@
+import type { UiDictionary } from './index';
+
+export const PROJECTS_EN: UiDictionary = {
+  // Titles
+  'projects.title.list': 'Projects',
+
+  // States
+  'projects.state.loading': 'Loading projects…',
+
+  // Actions / Buttons
+  'projects.action.add': 'Add new project',
+  'projects.action.editAria': 'Edit project',
+  'projects.action.openAria': 'Open project',
+  'projects.action.deleteAria': 'Delete project',
+
+  // Dialog fields
+  'projects.dialog.field.name': 'Project name',
+  'projects.dialog.field.description': 'Project description',
+
+  // Validation
+  'projects.validation.nameRequired': 'Name is required.',
+
+  // Dialog titles
+  'projects.dialog.title.create': 'Add new project',
+  'projects.dialog.title.edit': 'Edit project',
+
+  // Dialog actions (prefer shared)
+  // Save/Create/Cancel are shared.action.*
+
+  // Snackbar messages
+  'projects.message.created': 'Project created',
+  'projects.message.createFailed': 'Failed to create project',
+  'projects.message.updated': 'Project updated',
+  'projects.message.updateFailed': 'Failed to update project',
+  'projects.message.deleted': 'Project deleted',
+  'projects.message.deleteFailed': 'Failed to delete project',
+  'projects.message.loadFailed': 'Failed to load projects',
+
+  // Confirm delete dialog (with interpolation)
+  'projects.confirmDelete.title': 'Delete project "{projectName}"',
+  'projects.confirmDelete.message': 'Are you sure you want to delete the project "{projectName}"? This action cannot be undone.',
+};

--- a/frontend/src/app/shared/i18n/en/shared.ts
+++ b/frontend/src/app/shared/i18n/en/shared.ts
@@ -1,0 +1,11 @@
+import type { UiDictionary } from './index';
+
+export const SHARED_EN: UiDictionary = {
+  'shared.action.cancel': 'Cancel',
+  'shared.action.delete': 'Delete',
+  'shared.action.save': 'Save',
+  'shared.action.create': 'Create',
+  'shared.action.ok': 'OK',
+
+  'shared.aria.closeDialog': 'Close dialog',
+};

--- a/frontend/src/app/shared/i18n/en/tasks.ts
+++ b/frontend/src/app/shared/i18n/en/tasks.ts
@@ -1,0 +1,55 @@
+import type { UiDictionary } from './index';
+
+export const TASKS_EN: UiDictionary = {
+  // Titles / Sections
+  'tasks.title.section': 'Tasks',
+  'tasks.title.projectDetail': 'Project detail',
+
+  // States
+  'tasks.state.loadingProject': 'Loading project…',
+  'tasks.state.loadingTasks': 'Loading tasks…',
+
+  // Labels / UI
+  'tasks.label.due': 'Due:',
+
+  // Actions (feature-specific)
+  'tasks.action.add': 'Add new task',
+  'tasks.action.changeStatusAria': 'Change task status',
+  'tasks.action.editAria': 'Edit task',
+  'tasks.action.deleteAria': 'Delete task',
+
+  // Dialog fields
+  'tasks.dialog.field.title': 'Title',
+  'tasks.dialog.field.description': 'Description',
+  'tasks.dialog.field.dueDate': 'Due Date',
+  'tasks.dialog.field.status': 'Status',
+  'tasks.dialog.placeholder.dueDate': 'MM/DD/YYYY',
+
+  // Validation
+  'tasks.validation.titleRequired': 'Title is required.',
+
+  // Dialog titles
+  'tasks.dialog.title.create': 'Add new task',
+  'tasks.dialog.title.edit': 'Edit task',
+
+  // Status display labels
+  'tasks.status.todo': 'To do',
+  'tasks.status.inProgress': 'In progress',
+  'tasks.status.done': 'Done',
+
+  // Snackbar messages
+  'tasks.message.created': 'Task created',
+  'tasks.message.createFailed': 'Failed to create task',
+  'tasks.message.updated': 'Task updated',
+  'tasks.message.updateFailed': 'Failed to update task',
+  'tasks.message.deleted': 'Task deleted',
+  'tasks.message.deleteFailed': 'Failed to delete task',
+  'tasks.message.loadProjectFailed': 'Failed to load project',
+  'tasks.message.loadTasksFailed': 'Failed to load tasks for this project',
+  'tasks.message.statusUpdated': 'Status updated',
+  'tasks.message.statusUpdateFailed': 'Failed to update status',
+
+  // Confirm delete dialog (with interpolation)
+  'tasks.confirmDelete.title': 'Delete Task "{taskTitle}"',
+  'tasks.confirmDelete.message': 'Are you sure you want to delete the task "{taskTitle}"? This action cannot be undone.',
+};

--- a/frontend/src/app/shared/i18n/i18n.spec.ts
+++ b/frontend/src/app/shared/i18n/i18n.spec.ts
@@ -1,0 +1,89 @@
+import { UI_DICTIONARIES, type UiLang } from './index';
+
+type Dict = Record<string, string>;
+
+describe('i18n dictionaries', () => {
+  it('should include default language en', () => {
+    expect(UI_DICTIONARIES.en).toBeTruthy();
+  });
+
+  it('should expose at least one key for en', () => {
+    expect(Object.keys(UI_DICTIONARIES.en).length).toBeGreaterThan(0);
+  });
+
+  it('should contain only non-empty string values for each language', () => {
+    (Object.keys(UI_DICTIONARIES) as UiLang[]).forEach((lang) => {
+      assertAllStringsNonEmpty(UI_DICTIONARIES[lang], lang);
+    });
+  });
+
+  it('should have valid key format for each language', () => {
+    (Object.keys(UI_DICTIONARIES) as UiLang[]).forEach((lang) => {
+      assertValidKeys(UI_DICTIONARIES[lang], lang);
+    });
+  });
+});
+
+function assertAllStringsNonEmpty(dict: Dict, lang: string): void {
+  for (const [key, value] of Object.entries(dict)) {
+    if (typeof value !== 'string') {
+      fail(`[${lang}] Value for "${key}" is not a string`);
+    }
+    if (value.trim().length === 0) {
+      fail(`[${lang}] Value for "${key}" is empty`);
+    }
+  }
+}
+
+function assertValidKeys(dict: Dict, lang: string): void {
+  const allowedPrefixes = ['app', 'auth', 'projects', 'tasks', 'shared'];
+
+  for (const key of Object.keys(dict)) {
+    if (key.trim() !== key) {
+      fail(`[${lang}] Key has leading/trailing spaces: "${key}"`);
+    }
+    if (key.includes(' ')) {
+      fail(`[${lang}] Key must not contain spaces: "${key}"`);
+    }
+    if (key.includes('..')) {
+      fail(`[${lang}] Key must not contain "..": "${key}"`);
+    }
+    if (key.endsWith('.')) {
+      fail(`[${lang}] Key must not end with ".": "${key}"`);
+    }
+
+    // Must be prefix.something
+    const firstDot = key.indexOf('.');
+    if (firstDot <= 0) {
+      fail(`[${lang}] Key must start with a prefix followed by ".": "${key}"`);
+    }
+
+    const prefix = key.slice(0, firstDot);
+    const rest = key.slice(firstDot + 1);
+
+    if (!allowedPrefixes.includes(prefix)) {
+      fail(
+        `[${lang}] Invalid prefix "${prefix}" for key "${key}". Allowed: ${allowedPrefixes.join(', ')}`
+      );
+    }
+
+    if (rest.length === 0) {
+      fail(`[${lang}] Key must include a non-empty suffix after prefix: "${key}"`);
+    }
+
+    // Allow dot-separated camelCase segments:
+    // auth.login.validation.emailRequired
+    const segments = rest.split('.');
+    for (const segment of segments) {
+      if (segment.length === 0) {
+        fail(`[${lang}] Key contains an empty segment: "${key}"`);
+      }
+
+      if (!/^[a-z][a-zA-Z0-9_]*$/.test(segment)) {
+        fail(
+          `[${lang}] Invalid segment "${segment}" in key "${key}". Segments must start with a lowercase letter and may contain letters, digits, or underscores.`
+        );
+      }
+    }
+  }
+}

--- a/frontend/src/app/shared/i18n/index.ts
+++ b/frontend/src/app/shared/i18n/index.ts
@@ -1,0 +1,7 @@
+import { EN_DICTIONARY, type UiDictionary } from './en';
+
+export type UiLang = 'en';
+
+export const UI_DICTIONARIES: Record<UiLang, UiDictionary> = {
+  en: EN_DICTIONARY,
+};

--- a/frontend/src/app/shared/i18n/translate.pipe.ts
+++ b/frontend/src/app/shared/i18n/translate.pipe.ts
@@ -1,0 +1,37 @@
+import {
+  ChangeDetectorRef,
+  inject,
+  OnDestroy,
+  OnInit,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { UiTextService } from './ui-text.service';
+
+@Pipe({
+  name: 'translate',
+  standalone: true,
+  pure: false,
+})
+export class TranslatePipe implements PipeTransform, OnInit, OnDestroy {
+  private readonly translate = inject(UiTextService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  private sub?: Subscription;
+
+  ngOnInit(): void {
+    this.sub = this.translate.lang$.subscribe(() => {
+      this.cdr.markForCheck();
+    });
+  }
+
+  transform(key: string, params?: Record<string, unknown>): string {
+    return this.translate.t(key, params);
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+}

--- a/frontend/src/app/shared/i18n/ui-text.service.spec.ts
+++ b/frontend/src/app/shared/i18n/ui-text.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UiTextService } from './ui-text.service';
+
+describe('UiTextService (smoke)', () => {
+  let service: UiTextService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UiTextService);
+  });
+  
+  it('should return the expected value for a known key', () => {
+    expect(service.t('shared.action.cancel')).toBe('Cancel');
+  });
+
+  it('should return the key itself when missing', () => {
+    expect(service.t('missing.key')).toBe('missing.key');
+  });
+
+  it('should interpolate named placeholders', () => {
+    // Pick a key that exists in your dictionaries
+    // If you used: projects.confirmDelete.title = Delete project "{projectName}"
+    const result = service.t('projects.confirmDelete.title', { projectName: 'Demo' });
+    expect(result).toContain('Demo');
+    expect(result).not.toContain('{projectName}');
+  });
+
+  it('should keep unknown placeholders untouched', () => {
+    const result = service.t('projects.confirmDelete.title'); // no params
+    expect(result).toContain('{projectName}');
+  });
+
+  it('should fall back to default language when setting an unsupported language', () => {
+    // If UiLang is only 'en' right now, cast is fine for this smoke test
+    service.setLanguage('en' as any);
+    expect(service.getLanguage()).toBe('en');
+
+    service.setLanguage('xx' as any);
+    expect(service.getLanguage()).toBe('en');
+  });
+
+});

--- a/frontend/src/app/shared/i18n/ui-text.service.ts
+++ b/frontend/src/app/shared/i18n/ui-text.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import { UI_DICTIONARIES, type UiLang } from './index';
+
+@Injectable({ providedIn: 'root' })
+export class UiTextService {
+  private readonly defaultLang: UiLang = 'en';
+  private readonly langSubject = new BehaviorSubject<UiLang>(this.defaultLang);
+
+  readonly lang$ = this.langSubject.asObservable();
+
+  getLanguage(): UiLang {
+    return this.langSubject.value;
+  }
+
+  setLanguage(lang: UiLang): void {
+    // No lazy-load for now, just guard
+    if (!UI_DICTIONARIES[lang]) {
+      this.langSubject.next(this.defaultLang);
+      return;
+    }
+    this.langSubject.next(lang);
+  }
+
+  t(key: string, params?: Record<string, unknown>): string {
+    const lang = this.langSubject.value;
+    const dict = UI_DICTIONARIES[lang] ?? UI_DICTIONARIES[this.defaultLang];
+
+    const template = dict[key];
+    if (!template) {
+      // Returning the key makes missing translations visible during dev
+      return key;
+    }
+
+    return this.interpolate(template, params);
+  }
+
+  private interpolate(template: string, params?: Record<string, unknown>): string {
+    if (!params) return template;
+
+    return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+      if (!(name in params)) return match;
+      const value = params[name];
+      return value === null || value === undefined ? '' : String(value);
+    });
+  }
+}


### PR DESCRIPTION
Fixes #64 

- Adds the i18n-ready UI text foundation: EN dictionaries split by feature, merged entry points, UiTextService + translate pipe.
- Includes validation tests (key format + smoke for t() interpolation/fallback) and a dedicated i18n README.
- No UI strings refactor yet (will be done in next PR).