### PR TITLE
Refactor Auth UI strings (including app shell)

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,16 +1,16 @@
 <mat-toolbar color="primary" class="app-toolbar">
-  <h1 class="app-toolbar__title">{{ title() }}</h1>
+  <h1 class="app-toolbar__title">{{ 'app.title' | translate }}</h1>
 
 
   <div class="app-toolbar__actions">
     @if (auth.isLoggedIn()) {
     <a mat-button routerLink="/projects" routerLinkActive="active-link">
-      Projects
+      {{ 'app.nav.projects' | translate }}
     </a>
     }
 
     <button matButton="outlined" (click)="onAuthAction()">
-      {{ auth.isLoggedIn() ? 'Logout' : 'Login' }}
+      {{ authActionLabel | translate }}
     </button>
   </div>
 </mat-toolbar>

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -4,6 +4,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { Auth } from './services/auth';
 import { environment } from '../environments/environment';
+import { TranslatePipe } from './shared/i18n/translate.pipe';
 
 if (!environment.production) {
   console.info('[DEV] API base URL:', environment.apiBaseUrl);
@@ -11,14 +12,19 @@ if (!environment.production) {
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatButtonModule, MatToolbarModule],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatButtonModule, MatToolbarModule, TranslatePipe],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
 export class App {
-  protected readonly title = signal('Project Management App');
-  router = inject(Router);
-  public auth = inject(Auth);
+  readonly router = inject(Router);
+  readonly auth = inject(Auth);
+
+  get authActionLabel() {
+    return this.auth.isLoggedIn()
+      ? 'app.nav.logout'
+      : 'app.nav.login';
+  }
 
   onAuthAction() {
     if (this.auth.isLoggedIn()) {

--- a/frontend/src/app/pages/login/login.html
+++ b/frontend/src/app/pages/login/login.html
@@ -11,39 +11,38 @@
   </div>
 
   <form #formEl [formGroup]="form" (ngSubmit)="submit()" class="login-form">
-    <h2>Login</h2>
+    <h2>{{ 'auth.login.title' | translate }}</h2>
 
     <mat-form-field appearance="outline">
-      <mat-label>Email</mat-label>
+      <mat-label>{{ 'auth.login.label.email' | translate }}</mat-label>
 
       <input matInput type="email" formControlName="email"/>
 
       @if (emailCtrl.invalid && (emailCtrl.touched || submitAttempted)) {
         <mat-error>
           @if (emailCtrl.hasError('required')) {
-            <span>Email is required.</span>
+            <span>{{ 'auth.login.validation.emailRequired' | translate }}</span>
           }
           @if (emailCtrl.hasError('email')) {
-            <span>Please enter a valid email address.</span>
+            <span>{{ 'auth.login.validation.emailInvalid' | translate }}</span>
           }
         </mat-error>
       }
     </mat-form-field>
 
     <mat-form-field appearance="outline">
-      <mat-label>Password</mat-label>
-
+      <mat-label>{{ 'auth.login.label.password' | translate }}</mat-label>
       <input matInput type="password" formControlName="password"/>
 
       @if (passwordCtrl.invalid && (passwordCtrl.touched || submitAttempted)) {
         <mat-error>
-          Password is required.
+          {{ 'auth.login.validation.passwordRequired' | translate }}
         </mat-error>
       }
     </mat-form-field>
 
     <button matButton="outlined" color="primary" [disabled]="loading" type="submit">
-      Login
+      {{ 'auth.login.action.submit' | translate }}
     </button>
   </form>
 </div>

--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -6,10 +6,12 @@ import { Auth } from '../../services/auth';
 import { Router } from '@angular/router';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCardModule } from '@angular/material/card';
+import { UiTextService } from '../../shared/i18n/ui-text.service';
+import { TranslatePipe } from '../../shared/i18n/translate.pipe';
 
 @Component({
   selector: 'app-login',
-  imports: [MatCardModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [MatCardModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule, TranslatePipe],
   templateUrl: './login.html',
   styleUrl: './login.scss',
 })
@@ -17,9 +19,10 @@ export class Login {
   @ViewChild('formEl', { static: true }) private formEl?: ElementRef<HTMLFormElement>;
   error: string | null = null;
   loading = false;
-  router = inject(Router);
-  auth = inject(Auth);
-  formBuilder = inject(FormBuilder);
+  readonly router = inject(Router);
+  readonly auth = inject(Auth);
+  readonly formBuilder = inject(FormBuilder);
+  readonly translate = inject(UiTextService);
 
   submitAttempted = false;
 
@@ -57,7 +60,7 @@ export class Login {
       },
       error: () => {
         this.loading = false;
-        this.error = 'Invalid credentials';
+        this.error = this.translate.t('auth.login.error.invalidCredentials');
       },
     });
   }

--- a/frontend/src/app/shared/i18n/en/auth.ts
+++ b/frontend/src/app/shared/i18n/en/auth.ts
@@ -1,13 +1,21 @@
 import type { UiDictionary } from './index';
 
 export const AUTH_EN: UiDictionary = {
+    // Titles
   'auth.login.title': 'Login',
+
+  // Form fields
   'auth.login.label.email': 'Email',
   'auth.login.label.password': 'Password',
 
+  // Validation messages
   'auth.login.validation.emailRequired': 'Email is required.',
   'auth.login.validation.emailInvalid': 'Please enter a valid email address.',
   'auth.login.validation.passwordRequired': 'Password is required.',
 
+  // Actions / Buttons
+  'auth.login.action.submit': 'Login',
+  
+  // Error messages
   'auth.login.error.invalidCredentials': 'Invalid credentials',
 };


### PR DESCRIPTION
Fixes #66 

  - Refactors the app toolbar and login page to use centralized i18n-ready keys via the translate pipe and UiTextService.
  - Covers navigation labels, app title, login labels and validation messages, and the invalid credentials error.
  - No Projects/Tasks refactor included (handled in next PRs).