### PR TITLE
Refactor Projects UI strings (i18n-ready)

### DIFF
--- a/frontend/src/app/pages/project-detail/project-detail.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.ts
@@ -109,8 +109,8 @@ export class ProjectDetail {
       maxWidth: '80vw',
       panelClass: 'app-dialog',
       data: {
-        title: `Delete Task "${task.title}"`,
-        message: `Are you sure you want to delete the task "${task.title}"? This action cannot be undone.`,
+        titleKey: `Delete Task "${task.title}"`,
+        messageKey: `Are you sure you want to delete the task "${task.title}"? This action cannot be undone.`,
         confirmButtonLabel: 'Delete',
       } satisfies ConfirmDialogData,
     });

--- a/frontend/src/app/pages/projects/project-dialog.html
+++ b/frontend/src/app/pages/projects/project-dialog.html
@@ -1,7 +1,7 @@
 <div class="dialog-title">
-  <h2 mat-dialog-title>{{dialogTitle}}</h2>
+  <h2 mat-dialog-title>{{dialogTitle | translate}}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="Close dialog">
+  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{ 'shared.aria.closeDialog' | translate  }}">
     <mat-icon>close</mat-icon>
   </button>
 </div>
@@ -10,15 +10,15 @@
   <mat-dialog-content class="dialog-content">
 
     <mat-form-field class="full-width">
-      <mat-label>Project name</mat-label>
+      <mat-label>{{ 'projects.dialog.field.name' | translate }}</mat-label>
       <input matInput formControlName="name" cdkFocusInitial/>
       @if (nameCtrl.invalid && (nameCtrl.touched || submitAttempted)) {
-        <mat-error>Name is required.</mat-error>
+        <mat-error>{{ 'projects.validation.nameRequired' | translate }}</mat-error>
       }
     </mat-form-field>
 
     <mat-form-field class="full-width">
-      <mat-label>Project description</mat-label>
+      <mat-label>{{ 'projects.dialog.field.description' | translate }}</mat-label>
       <textarea
         matInput
         formControlName="description"
@@ -32,9 +32,9 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button matButton type="button" (click)="clickOnCancel()">Cancel</button>
+    <button matButton type="button" (click)="clickOnCancel()">{{ 'shared.action.cancel' | translate }}</button>
     <button matButton type="submit">
-      {{primaryButtonLabel}}
+      {{primaryButtonLabel | translate}}
     </button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/pages/projects/project-dialog.spec.ts
+++ b/frontend/src/app/pages/projects/project-dialog.spec.ts
@@ -91,8 +91,8 @@ describe('ProjectDialog', () => {
 
   it('should expose correct title and primary label in create mode', () => {
     const { component } = createComponent({ mode: 'create' });
-    expect(component.dialogTitle).toBe('Add new project');
-    expect(component.primaryButtonLabel).toBe('Create');
+    expect(component.dialogTitle).toBe('projects.dialog.title.create');
+    expect(component.primaryButtonLabel).toBe('shared.action.create');
   });
 
   it('should expose correct title and primary label in edit mode', () => {
@@ -100,8 +100,8 @@ describe('ProjectDialog', () => {
       mode: 'edit',
       project: { id: 'p1', name: 'Old', description: 'desc' },
     });
-    expect(component.dialogTitle).toBe('Edit project');
-    expect(component.primaryButtonLabel).toBe('Save');
+    expect(component.dialogTitle).toBe('projects.dialog.title.edit');
+    expect(component.primaryButtonLabel).toBe('shared.action.save');
   });
 
   function createComponent(data?: ProjectDialogData) {

--- a/frontend/src/app/pages/projects/project-dialog.ts
+++ b/frontend/src/app/pages/projects/project-dialog.ts
@@ -13,6 +13,8 @@ import { MatInputModule } from '@angular/material/input';
 import { CreateProjectRequest, Project } from '../../services/projects';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ProjectDialogData, ProjectDialogResult } from './project-dialog.types';
+import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+
 @Component({
   selector: 'project-dialog',
   templateUrl: 'project-dialog.html',
@@ -27,6 +29,7 @@ import { ProjectDialogData, ProjectDialogResult } from './project-dialog.types';
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    TranslatePipe,
   ],
 })
 export class ProjectDialog implements OnInit {
@@ -51,11 +54,11 @@ export class ProjectDialog implements OnInit {
   }
 
   get dialogTitle(): string {
-    return this.isEdit ? 'Edit project' : 'Add new project';
+    return this.isEdit ? 'projects.dialog.title.edit' : 'projects.dialog.title.create';
   }
 
   get primaryButtonLabel(): string {
-    return this.isEdit ? 'Save' : 'Create';
+    return this.isEdit ? 'shared.action.save' : 'shared.action.create';
   }
 
   ngOnInit() {

--- a/frontend/src/app/pages/projects/projects.html
+++ b/frontend/src/app/pages/projects/projects.html
@@ -1,13 +1,13 @@
 <section class="page">
   <header class="page-header">
-    <h2 class="page-title">Projects</h2>
+    <h2 class="page-title">{{ 'projects.title.list' | translate }}</h2>
   </header>
 
   <div class="page-status">
     @if (loading) {
       <mat-card class="status-card status-info">
         <mat-card-content>
-          Loading projects…
+          {{ 'projects.state.loading' | translate }}
         </mat-card-content>
       </mat-card>
     }
@@ -25,7 +25,7 @@
   <div class="page-actions">
     <button matButton="outlined" color="primary" (click)="openAddNewProjectDialog()">
       <mat-icon>add</mat-icon>
-      Add new project
+      {{ 'projects.action.add' | translate }}
     </button>
   </div>
 
@@ -38,17 +38,17 @@
 
         <span matListItemMeta class="item-meta">
           <button mat-icon-button class="icon-action" (click)="openEditProjectDialog(project)"
-            aria-label="Edit project">
+            aria-label="{{ 'projects.action.editAria' | translate }}">
             <mat-icon>edit</mat-icon>
           </button>
 
           <button mat-icon-button class="icon-action" (click)="showProjectDetail(project.id)"
-            aria-label="Open project">
+            aria-label="{{ 'projects.action.openAria' | translate }}">
             <mat-icon>visibility</mat-icon>
           </button>
 
           <button mat-icon-button class="icon-action" (click)="openDeleteProjectConfirmDialog(project)"
-            aria-label="Delete project">
+            aria-label="{{ 'projects.action.deleteAria' | translate }}">
             <mat-icon>delete_forever</mat-icon>
           </button>
         </span>

--- a/frontend/src/app/pages/projects/projects.ts
+++ b/frontend/src/app/pages/projects/projects.ts
@@ -15,19 +15,21 @@ import { ConfirmDialogData } from '../../shared/dialogs/confirm-dialog.types';
 import { MatListModule } from '@angular/material/list';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatCardModule } from '@angular/material/card';
-
+import { UiTextService } from '../../shared/i18n/ui-text.service';
+import { TranslatePipe } from '../../shared/i18n/translate.pipe';
 @Component({
   selector: 'app-projects',
   standalone: true,
-  imports: [MatListModule, MatDividerModule, MatButtonModule, MatCardModule, MatIconModule, MatDialogModule, MatSnackBarModule],
+  imports: [MatListModule, MatDividerModule, MatButtonModule, MatCardModule, MatIconModule, MatDialogModule, MatSnackBarModule, TranslatePipe],
   templateUrl: './projects.html',
   styleUrl: './projects.scss',
 })
 export class Projects {
-  router = inject(Router);
-  private projectsService = inject(ProjectsService);
-  private snackBar = inject(MatSnackBar);
+  readonly router = inject(Router);
   readonly dialog = inject(MatDialog);
+  private readonly projectsService = inject(ProjectsService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly translate = inject(UiTextService);
 
   projects: Project[] = [];
   loading = false;
@@ -48,10 +50,10 @@ export class Projects {
         next: () => {
           // refresh list
           this.loadProjects();
-          this.notify('Project created');
+          this.notify(this.translate.t('projects.message.created'));
         },
         error: () => {
-          this.error = 'Failed to create project';
+          this.error = this.translate.t('projects.message.createFailed');
           this.notify(this.error);
         },
       });
@@ -73,10 +75,10 @@ export class Projects {
         next: () => {
           // refresh list
           this.loadProjects();
-          this.notify('Project updated');
+          this.notify(this.translate.t('projects.message.updated'));
         },
         error: () => {
-          this.error = 'Failed to update project';
+          this.error = this.translate.t('projects.message.updateFailed');
           this.notify(this.error);
         },
       });
@@ -89,9 +91,11 @@ export class Projects {
       maxWidth: '80vw',
       panelClass: 'app-dialog',
       data: {
-        title: `Delete project "${project.name}"`,
-        message: `Are you sure you want to delete the project "${project.name}"? This action cannot be undone.`,
-        confirmButtonLabel: 'Delete',
+        titleKey: 'projects.confirmDelete.title',
+        titleParams: { projectName: project.name },
+        messageKey: 'projects.confirmDelete.message',
+        messageParams: { projectName: project.name },
+        confirmButtonLabel: 'shared.action.delete',
       } satisfies ConfirmDialogData,
     });
 
@@ -102,10 +106,10 @@ export class Projects {
         next: () => {
           // refresh list
           this.loadProjects();
-          this.notify('Project deleted');
+          this.notify(this.translate.t('projects.message.deleted'));
         },
         error: () => {
-          this.error = 'Failed to delete project';
+          this.error = this.translate.t('projects.message.deleteFailed');
           this.notify(this.error);
         },
       });
@@ -122,7 +126,7 @@ export class Projects {
         this.loading = false;
       },
       error: () => {
-        this.error = 'Failed to load projects';
+        this.error = this.translate.t('projects.message.loadFailed');
         this.loading = false;
         this.notify(this.error);
       },
@@ -135,7 +139,7 @@ export class Projects {
   }
 
   private notify(message: string) {
-    this.snackBar.open(message, 'Close', { duration: 3000 });
+    this.snackBar.open(message, this.translate.t('shared.action.close'), { duration: 3000 });
   }
 
   ngOnInit() {

--- a/frontend/src/app/shared/dialogs/confirm-dialog.html
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.html
@@ -1,21 +1,21 @@
 <div  class="dialog-titlebar">
-  <h2 mat-dialog-title class="dialog-title">{{title}}</h2>
+  <h2 mat-dialog-title class="dialog-title">{{titleKey | translate:titleParams }}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="Close dialog" class="dialog-close-btn">
+  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
     <mat-icon>close</mat-icon>
   </button>
 </div>
 
 <mat-dialog-content class="dialog-content">
-  <p>{{message}}</p>
+  <p>{{messageKey | translate:messageParams }}</p>
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button matButton (click)="clickOnCancel()">{{cancelButtonLabel}}</button>
+  <button matButton (click)="clickOnCancel()">{{cancelButtonLabel | translate}}</button>
   <button
     matButton (click)="clickOnConfirm()"
     cdkFocusInitial
   >
-    {{confirmButtonLabel}}
+    {{confirmButtonLabel | translate}}
   </button>
 </mat-dialog-actions>

--- a/frontend/src/app/shared/dialogs/confirm-dialog.spec.ts
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.spec.ts
@@ -17,32 +17,32 @@ describe('ConfirmDialog', () => {
       providers: [
         provideNativeDateAdapter(),
         { provide: MatDialogRef, useValue: dialogRefSpy },
-        { provide: MAT_DIALOG_DATA, useValue: { title: 'Dialog title', message: 'Dialog message' } satisfies ConfirmDialogData },
+        { provide: MAT_DIALOG_DATA, useValue: { titleKey: 'Dialog title', messageKey: 'Dialog message' } satisfies ConfirmDialogData },
       ],
     }).compileComponents();
   });
 
   it('should default button labels display when they are not provided', () => {
     const { component } = createComponent({
-      title: 'Dialog title',
-      message: 'Dialog message',
+      titleKey: 'Dialog title',
+      messageKey: 'Dialog message',
     } satisfies ConfirmDialogData);
 
-    expect(component.cancelButtonLabel).toBe('Cancel');
-    expect(component.confirmButtonLabel).toBe('OK');
+    expect(component.cancelButtonLabel).toBe('shared.action.cancel');
+    expect(component.confirmButtonLabel).toBe('shared.action.ok');
   });
 
   it('should title and message empty when they are not provided', () => {
     const { component } = createComponent({} as unknown as ConfirmDialogData);
 
-    expect(component.title).toBe('');
-    expect(component.message).toBe('');
+    expect(component.titleKey).toBe('');
+    expect(component.messageKey).toBe('');
   });
 
   it('should click on confirm button return true', () => {
     const { component } = createComponent({
-      title: 'Dialog title',
-      message: 'Dialog message',
+      titleKey: 'Dialog title',
+      messageKey: 'Dialog message',
     } satisfies ConfirmDialogData);
 
     component.clickOnConfirm();
@@ -53,8 +53,8 @@ describe('ConfirmDialog', () => {
 
   it('should click on cancel button return undefined', () => {
     const { component } = createComponent({
-      title: 'Dialog title',
-      message: 'Dialog message',
+      titleKey: 'Dialog title',
+      messageKey: 'Dialog message',
     } satisfies ConfirmDialogData);
 
     component.clickOnCancel();

--- a/frontend/src/app/shared/dialogs/confirm-dialog.ts
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.ts
@@ -3,6 +3,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
 import { MatIconModule } from "@angular/material/icon";
 import { ConfirmDialogData } from "./confirm-dialog.types";
+import { TranslatePipe } from "../i18n/translate.pipe";
 
 @Component({
   selector: 'confirm-dialog',
@@ -15,6 +16,7 @@ import { ConfirmDialogData } from "./confirm-dialog.types";
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    TranslatePipe,
   ],
 })
 export class ConfirmDialog {
@@ -22,13 +24,17 @@ export class ConfirmDialog {
   readonly data = inject<ConfirmDialogData>(MAT_DIALOG_DATA);
 
 
-  get title(): string { return this.data.title ?? '';}
+  get titleKey(): string { return this.data.titleKey ?? '';}
 
-  get message(): string { return this.data.message ?? ''; }
+  get titleParams(): Record<string, unknown> | undefined { return this.data.titleParams; }
 
-  get cancelButtonLabel(): string { return this.data.cancelButtonLabel || 'Cancel'; }
+  get messageKey(): string { return this.data.messageKey ?? ''; }
 
-  get confirmButtonLabel(): string { return this.data.confirmButtonLabel || 'OK'; }
+  get messageParams(): Record<string, unknown> | undefined { return this.data.messageParams; }
+
+  get cancelButtonLabel(): string { return this.data.cancelButtonLabel || 'shared.action.cancel'; }
+
+  get confirmButtonLabel(): string { return this.data.confirmButtonLabel || 'shared.action.ok'; }
 
   clickOnConfirm(): void {
     this.dialogRef.close(true);

--- a/frontend/src/app/shared/dialogs/confirm-dialog.types.ts
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.types.ts
@@ -1,6 +1,8 @@
 export interface ConfirmDialogData {
-  title: string;
-  message: string;
+  titleKey: string;
+  titleParams?: Record<string, unknown>;
+  messageKey: string;
+  messageParams?: Record<string, unknown>;
   confirmButtonLabel?: string;
   cancelButtonLabel?: string;
 }

--- a/frontend/src/app/shared/i18n/en/shared.ts
+++ b/frontend/src/app/shared/i18n/en/shared.ts
@@ -1,6 +1,7 @@
 import type { UiDictionary } from './index';
 
 export const SHARED_EN: UiDictionary = {
+  'shared.action.close': 'Close',
   'shared.action.cancel': 'Cancel',
   'shared.action.delete': 'Delete',
   'shared.action.save': 'Save',


### PR DESCRIPTION
Fixes #67 

  - Replaces all Projects user-visible strings (templates + TS) with centralized translation keys.
  - Updates shared confirm dialog usage to support placeholder params via ConfirmDialogData (projectName interpolation).
  - Adjusts unit tests to match updated labels and confirm dialog data structure.
  - No Tasks refactor included (handled in US#14.5).