### PR TITLE
Refactor Tasks UI strings and confirm dialog placeholders

### DIFF
--- a/frontend/src/app/pages/project-detail/project-detail.html
+++ b/frontend/src/app/pages/project-detail/project-detail.html
@@ -5,7 +5,7 @@
     @if (loadingProject) {
       <mat-card class="status-card status-info">
         <mat-card-content>
-          Loading project…
+          {{ 'tasks.state.loadingProject' | translate }}
         </mat-card-content>
       </mat-card>
     }
@@ -21,7 +21,7 @@
     @if (loadingTasks) {
       <mat-card class="status-card status-info">
         <mat-card-content>
-          Loading tasks…
+          {{ 'tasks.state.loadingTasks' | translate }}
         </mat-card-content>
       </mat-card>
     }
@@ -37,7 +37,7 @@
 
   <mat-card class="example-card" appearance="outlined">
     <mat-card-header>
-      <mat-card-title><strong>{{ project?.name }}</strong> project detail</mat-card-title>
+      <mat-card-title><strong>{{ project?.name }}</strong> {{ 'tasks.title.projectDetail' | translate }}</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <p>{{ project?.description }}</p>
@@ -45,13 +45,13 @@
   </mat-card>
 
   <header class="page-header">
-    <h2>Tasks</h2>
+    <h2>{{ 'tasks.title.section' | translate }}</h2>
   </header>
 
   <div class="page-actions">
     <button matButton="outlined" color="primary" (click)="openAddNewTaskDialog()">
       <mat-icon>add</mat-icon>
-      Add new task
+      {{ 'tasks.action.add' | translate }}
     </button>
   </div>
 
@@ -65,7 +65,7 @@
         }
 
         <span matListItemLine class="task-subline">
-          Due: {{ task.dueDate | date }}
+          {{ 'tasks.label.due' | translate }} {{ task.dueDate | date }}
         </span>
 
         <span matListItemMeta class="item-meta">
@@ -74,18 +74,18 @@
             class="status-btn"
             (click)="onStatusClick(task)"
             [disabled]="updatingTaskId === task.id"
-            aria-label="Change task status"
+            aria-label="{{ 'tasks.action.changeStatusAria' | translate }}"
           >
             <span class="status-emoji">{{ statusEmoji(task.status) }}</span>
-            <span class="status-label">{{ statusLabel(task.status) }}</span>
+            <span class="status-label">{{ statusLabel(task.status) | translate }}</span>
           </button>
 
           <span class="item-actions">
-            <button matIconButton class="icon-action" (click)="openEditTaskDialog(task)" aria-label="Edit task">
+            <button matIconButton class="icon-action" (click)="openEditTaskDialog(task)" aria-label="{{ 'tasks.action.editAria' | translate }}">
               <mat-icon>edit</mat-icon>
             </button>
 
-            <button matIconButton class="icon-action" (click)="openDeleteTaskConfirmDialog(task)" aria-label="Delete task">
+            <button matIconButton class="icon-action" (click)="openDeleteTaskConfirmDialog(task)" aria-label="{{ 'tasks.action.deleteAria' | translate }}">
               <mat-icon>delete_forever</mat-icon>
             </button>
           </span>

--- a/frontend/src/app/pages/project-detail/project-detail.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.ts
@@ -16,18 +16,21 @@ import { ConfirmDialog } from '../../shared/dialogs/confirm-dialog';
 import { ConfirmDialogData } from '../../shared/dialogs/confirm-dialog.types';
 import { MatListModule } from '@angular/material/list';
 import { MatCardModule } from '@angular/material/card';
+import { UiTextService } from '../../shared/i18n/ui-text.service';
+import { TranslatePipe } from '../../shared/i18n/translate.pipe';
 
 @Component({
   selector: 'app-project-detail',
   standalone: true,
-  imports: [DatePipe, MatListModule, MatCardModule, MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule],
+  imports: [DatePipe, MatListModule, MatCardModule, MatButtonModule, MatIconModule, MatDialogModule, MatSnackBarModule, TranslatePipe],
   templateUrl: './project-detail.html',
   styleUrl: './project-detail.scss',
 })
 export class ProjectDetail {
-  private projectsService = inject(ProjectsService);
-  private tasksService = inject(TasksService);
-  private route = inject(ActivatedRoute);
+  private readonly projectsService = inject(ProjectsService);
+  private readonly tasksService = inject(TasksService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly translate = inject(UiTextService);
   readonly dialog = inject(MatDialog);
 
   id: string | null = this.route.snapshot.paramMap.get('id');
@@ -42,7 +45,7 @@ export class ProjectDetail {
   updatingTaskId: string | null = null;
 
   private notify(message: string) {
-    this.snackBar.open(message, 'Close', { duration: 3000 });
+    this.snackBar.open(message, this.translate.t('shared.action.close'), { duration: 3000 });
   }
 
   openAddNewTaskDialog() {
@@ -64,10 +67,10 @@ export class ProjectDetail {
           // refresh list
           this.loadingTasks = true;
           this.loadTasks();
-          this.notify('Task created');
+          this.notify(this.translate.t('tasks.message.created'));
         },
         error: () => {
-          this.errorTasks = 'Failed to create task';
+          this.errorTasks = this.translate.t('tasks.message.createFailed');
           this.notify(this.errorTasks);
         },
       });
@@ -93,10 +96,10 @@ export class ProjectDetail {
           // refresh list
           this.loadingTasks = true;
           this.loadTasks();
-          this.notify('Task updated');
+          this.notify(this.translate.t('tasks.message.updated'));
         },
         error: () => {
-          this.errorTasks = 'Failed to update task';
+          this.errorTasks = this.translate.t('tasks.message.updateFailed');
           this.notify(this.errorTasks);
         },
       });
@@ -109,9 +112,11 @@ export class ProjectDetail {
       maxWidth: '80vw',
       panelClass: 'app-dialog',
       data: {
-        titleKey: `Delete Task "${task.title}"`,
-        messageKey: `Are you sure you want to delete the task "${task.title}"? This action cannot be undone.`,
-        confirmButtonLabel: 'Delete',
+        titleKey: 'tasks.confirmDelete.title',
+        titleParams: { taskTitle: task.title },
+        messageKey: 'tasks.confirmDelete.message',
+        messageParams: { taskTitle: task.title },
+        confirmButtonLabel: 'shared.action.delete',
       } satisfies ConfirmDialogData,
     });
 
@@ -125,10 +130,10 @@ export class ProjectDetail {
           // refresh list
           this.loadingTasks = true;
           this.loadTasks();
-          this.notify('Task deleted');
+          this.notify(this.translate.t('tasks.message.deleted'));
         },
         error: () => {
-          this.errorTasks = 'Failed to delete task';
+          this.errorTasks = this.translate.t('tasks.message.deleteFailed');
           this.notify(this.errorTasks);
         },
       });
@@ -147,7 +152,7 @@ export class ProjectDetail {
         this.loadingProject = false;
       },
       error: () => {
-        this.errorProject = 'Failed to load project';
+        this.errorProject = this.translate.t('tasks.message.loadProjectFailed');
         this.loadingProject = false;
         this.notify(this.errorProject);
       },
@@ -166,7 +171,7 @@ export class ProjectDetail {
         this.loadingTasks = false;
       },
       error: () => {
-        this.errorTasks = 'Failed to load tasks for this project';
+        this.errorTasks = this.translate.t('tasks.message.loadTasksFailed');
         this.loadingTasks = false;
         this.notify(this.errorTasks);
       },
@@ -189,13 +194,13 @@ export class ProjectDetail {
     this.tasksService.updateStatus(task.id, next).subscribe({
       next: () => {
         this.updatingTaskId = null;
-        this.notify('Status updated');
+        this.notify(this.translate.t('tasks.message.statusUpdated'));
       },
       error: () => {
         // rollback
         task.status = previous;
         this.updatingTaskId = null;
-        this.notify('Failed to update status');
+        this.notify(this.translate.t('tasks.message.statusUpdateFailed'));
       }
     });
   }
@@ -210,9 +215,9 @@ export class ProjectDetail {
 
   statusLabel(status: TaskStatus): string {
     switch (status) {
-      case 'TODO': return 'To do';
-      case 'IN_PROGRESS': return 'In progress';
-      case 'DONE': return 'Done';
+      case 'TODO': return 'tasks.status.todo';
+      case 'IN_PROGRESS': return 'tasks.status.inProgress';
+      case 'DONE': return 'tasks.status.done';
     }
   }
 

--- a/frontend/src/app/pages/project-detail/task-dialog.html
+++ b/frontend/src/app/pages/project-detail/task-dialog.html
@@ -1,7 +1,7 @@
 <div class="dialog-title">
-  <h2 mat-dialog-title>{{ dialogTitle }}</h2>
+  <h2 mat-dialog-title>{{ dialogTitle | translate }}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="Close dialog">
+  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
     <mat-icon>close</mat-icon>
   </button>
 </div>
@@ -10,43 +10,43 @@
 
   <mat-dialog-content class="dialog-content">
     <mat-form-field appearance="fill" class="full-width">
-      <mat-label>Title</mat-label>
+      <mat-label>{{ 'tasks.dialog.field.title' | translate }}</mat-label>
       <input matInput formControlName="title" cdkFocusInitial/>
       @if (titleCtrl.invalid && (titleCtrl.touched || submitAttempted)) {
-        <mat-error>Title is required.</mat-error>
+        <mat-error>{{ 'tasks.validation.titleRequired' | translate }}</mat-error>
       }
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="full-width">
-      <mat-label>Description</mat-label>
+      <mat-label>{{ 'tasks.dialog.field.description' | translate }}</mat-label>
       <textarea matInput formControlName="description" cdkTextareaAutosize cdkAutosizeMinRows="3"
         cdkAutosizeMaxRows="8">
       </textarea>
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="full-width">
-      <mat-label>Due Date</mat-label>
+      <mat-label>{{ 'tasks.dialog.field.dueDate' | translate }}</mat-label>
       <input matInput [matDatepicker]="picker" formControlName="dueDate" />
-      <mat-hint>MM/DD/YYYY</mat-hint>
+      <mat-hint>{{ 'tasks.dialog.placeholder.dueDate' | translate }}</mat-hint>
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="full-width">
-      <mat-label>Status</mat-label>
+      <mat-label>{{ 'tasks.dialog.field.status' | translate }}</mat-label>
       <mat-select formControlName="status">
-        <mat-option value="TODO">To do</mat-option>
-        <mat-option value="IN_PROGRESS">In progress</mat-option>
-        <mat-option value="DONE">Done</mat-option>
+        <mat-option value="TODO">{{ 'tasks.status.todo' | translate }}</mat-option>
+        <mat-option value="IN_PROGRESS">{{ 'tasks.status.inProgress' | translate }}</mat-option>
+        <mat-option value="DONE">{{ 'tasks.status.done' | translate }}</mat-option>
       </mat-select>
     </mat-form-field>
 
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button mat-button type="button" (click)="clickOnCancel()">Cancel</button>
+    <button mat-button type="button" (click)="clickOnCancel()">{{'shared.action.cancel' | translate}}</button>
     <button mat-button type="submit">
-      {{ primaryButtonLabel }}
+      {{ primaryButtonLabel | translate }}
     </button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/pages/project-detail/task-dialog.spec.ts
+++ b/frontend/src/app/pages/project-detail/task-dialog.spec.ts
@@ -116,8 +116,8 @@ describe('TaskDialog', () => {
 
   it('should expose correct title and primary label in create mode', () => {
     const { component } = createComponent({ mode: 'create' });
-    expect(component.dialogTitle).toBe('Add new task');
-    expect(component.primaryButtonLabel).toBe('Create');
+    expect(component.dialogTitle).toBe('tasks.dialog.title.create');
+    expect(component.primaryButtonLabel).toBe('shared.action.create');
   });
 
   it('should expose correct title and primary label in edit mode', () => {
@@ -125,8 +125,8 @@ describe('TaskDialog', () => {
       mode: 'edit',
       task: { id: 't1', projectId: 'p1', title: 'x', status: 'TODO' },
     });
-    expect(component.dialogTitle).toBe('Edit task');
-    expect(component.primaryButtonLabel).toBe('Save');
+    expect(component.dialogTitle).toBe('tasks.dialog.title.edit');
+    expect(component.primaryButtonLabel).toBe('shared.action.save');
   });
 
   function createComponent(data?: TaskDialogData) {

--- a/frontend/src/app/pages/project-detail/task-dialog.ts
+++ b/frontend/src/app/pages/project-detail/task-dialog.ts
@@ -10,6 +10,9 @@ import { MatSelectModule } from "@angular/material/select";
 import { CreateTaskRequest, Task, TaskStatus } from "../../services/tasks";
 import { TaskDialogData, TaskDialogResult } from './task-dialog.types';
 import { toIsoLocalDateString } from "../../shared/functions/date";
+import { UiTextService } from "../../shared/i18n/ui-text.service";
+import { TranslatePipe } from "../../shared/i18n/translate.pipe";
+
 @Component({
   selector: 'task-dialog',
   templateUrl: 'task-dialog.html',
@@ -26,13 +29,15 @@ import { toIsoLocalDateString } from "../../shared/functions/date";
     MatDialogActions,
     MatDatepickerModule,
     MatSelectModule,
+    TranslatePipe,
   ],
 })
 export class TaskDialog implements OnInit {
   @ViewChild('formEl', { static: true }) private formEl?: ElementRef<HTMLFormElement>;
-  readonly dialogRef = inject(MatDialogRef<TaskDialog>);
-  readonly data = inject<TaskDialogData>(MAT_DIALOG_DATA);
-  readonly formBuilder = inject(FormBuilder);
+  private readonly dialogRef = inject(MatDialogRef<TaskDialog>);
+  private readonly data = inject<TaskDialogData>(MAT_DIALOG_DATA);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly translate = inject(UiTextService);
 
   submitAttempted = false;
 
@@ -52,11 +57,11 @@ export class TaskDialog implements OnInit {
   }
 
   get dialogTitle(): string {
-    return this.isEdit ? 'Edit task' : 'Add new task';
+    return this.isEdit ? 'tasks.dialog.title.edit' : 'tasks.dialog.title.create';
   }
 
   get primaryButtonLabel(): string {
-    return this.isEdit ? 'Save' : 'Create';
+    return this.isEdit ? 'shared.action.save' : 'shared.action.create';
   }
 
   ngOnInit() {

--- a/frontend/src/app/pages/projects/projects.ts
+++ b/frontend/src/app/pages/projects/projects.ts
@@ -17,6 +17,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatCardModule } from '@angular/material/card';
 import { UiTextService } from '../../shared/i18n/ui-text.service';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+
 @Component({
   selector: 'app-projects',
   standalone: true,

--- a/frontend/src/app/shared/i18n/en/tasks.ts
+++ b/frontend/src/app/shared/i18n/en/tasks.ts
@@ -3,7 +3,7 @@ import type { UiDictionary } from './index';
 export const TASKS_EN: UiDictionary = {
   // Titles / Sections
   'tasks.title.section': 'Tasks',
-  'tasks.title.projectDetail': 'Project detail',
+  'tasks.title.projectDetail': 'project detail',
 
   // States
   'tasks.state.loadingProject': 'Loading project…',


### PR DESCRIPTION
Fixes #68 

  - Replaces all Tasks user-visible strings (templates + TS) with centralized translation keys.
  - Updates task-related confirm delete dialogs to use placeholder params via ConfirmDialogData (taskTitle interpolation).
  - Ensures status labels, loading states, aria-labels, and snackbar messages are fully i18n-ready.
  - Adjusts unit tests to match updated labels and confirm dialog data structure.
  - No Shared/App shell refactor included (handled in US#14.6).