### PR TITLE
Improve dialog consistency and maintainability

### DIFF
--- a/frontend/src/app/pages/project-detail/task-dialog.html
+++ b/frontend/src/app/pages/project-detail/task-dialog.html
@@ -1,7 +1,7 @@
-<div class="dialog-title">
-  <h2 mat-dialog-title>{{ dialogTitle | translate }}</h2>
+<div class="dialog-titlebar">
+  <h2 mat-dialog-title class="dialog-title">{{ dialogTitle | translate }}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
+  <button type="button" mat-icon-button mat-dialog-close aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
     <mat-icon>close</mat-icon>
   </button>
 </div>
@@ -44,8 +44,8 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button mat-button type="button" (click)="clickOnCancel()">{{'shared.action.cancel' | translate}}</button>
-    <button mat-button type="submit">
+    <button matButton type="button" mat-dialog-close>{{'shared.action.cancel' | translate}}</button>
+    <button matButton type="submit">
       {{ primaryButtonLabel | translate }}
     </button>
   </mat-dialog-actions>

--- a/frontend/src/app/pages/project-detail/task-dialog.scss
+++ b/frontend/src/app/pages/project-detail/task-dialog.scss
@@ -1,3 +1,5 @@
+@use '../../shared/dialogs/common' as *;
+
 :host {
   display: block;
   overflow-x: hidden;
@@ -7,12 +9,6 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-.dialog-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .full-width {

--- a/frontend/src/app/pages/project-detail/task-dialog.ts
+++ b/frontend/src/app/pages/project-detail/task-dialog.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, inject, OnInit, ViewChild, viewChild } from "@an
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
 import { MatDatepickerModule } from "@angular/material/datepicker";
-import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
+import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogModule, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
@@ -19,6 +19,7 @@ import { TranslatePipe } from "../../shared/i18n/translate.pipe";
   styleUrl: 'task-dialog.scss',
   standalone: true,
   imports: [
+    MatDialogModule,
     MatButtonModule,
     MatIconModule,
     ReactiveFormsModule,
@@ -93,10 +94,6 @@ export class TaskDialog implements OnInit {
       : { mode: 'create', payload };
 
     this.dialogRef.close(result);
-  }
-
-  clickOnCancel(): void {
-    this.dialogRef.close();
   }
 
   private prefillFromTask(task: Task) {

--- a/frontend/src/app/pages/projects/project-dialog.html
+++ b/frontend/src/app/pages/projects/project-dialog.html
@@ -1,7 +1,7 @@
-<div class="dialog-title">
-  <h2 mat-dialog-title>{{dialogTitle | translate}}</h2>
+<div class="dialog-titlebar">
+  <h2 mat-dialog-title class="dialog-title">{{dialogTitle | translate}}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{ 'shared.aria.closeDialog' | translate  }}">
+  <button type="button" mat-icon-button mat-dialog-close aria-label="{{ 'shared.aria.closeDialog' | translate  }}" class="dialog-close-btn">
     <mat-icon>close</mat-icon>
   </button>
 </div>
@@ -32,7 +32,7 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button matButton type="button" (click)="clickOnCancel()">{{ 'shared.action.cancel' | translate }}</button>
+    <button matButton type="button" mat-dialog-close>{{ 'shared.action.cancel' | translate }}</button>
     <button matButton type="submit">
       {{primaryButtonLabel | translate}}
     </button>

--- a/frontend/src/app/pages/projects/project-dialog.scss
+++ b/frontend/src/app/pages/projects/project-dialog.scss
@@ -1,3 +1,5 @@
+@use '../../shared/dialogs/common' as *;
+
 :host {
   display: block;
   overflow-x: hidden;
@@ -7,12 +9,6 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-.dialog-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .full-width {

--- a/frontend/src/app/pages/projects/project-dialog.ts
+++ b/frontend/src/app/pages/projects/project-dialog.ts
@@ -6,7 +6,8 @@ import {
   MatDialogActions,
   MatDialogContent,
   MatDialogTitle,
-  MAT_DIALOG_DATA
+  MAT_DIALOG_DATA,
+  MatDialogModule
 } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -24,6 +25,7 @@ import { TranslatePipe } from '../../shared/i18n/translate.pipe';
     MatButtonModule,
     MatIconModule,
     ReactiveFormsModule,
+    MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
     MatDialogTitle,
@@ -88,10 +90,6 @@ export class ProjectDialog implements OnInit {
       : { mode: 'create', payload };
 
     this.dialogRef.close(result);
-  }
-
-  clickOnCancel(): void {
-    this.dialogRef.close();
   }
 
   private prefillFromProject(project: Project) {

--- a/frontend/src/app/shared/dialogs/common.scss
+++ b/frontend/src/app/shared/dialogs/common.scss
@@ -1,0 +1,17 @@
+.dialog-titlebar {
+  position: relative;
+}
+
+/* Keep Material title styling, just reserve space for the close button */
+.dialog-title {
+  padding-right: 56px; // space for close button + margin
+  margin: 0;           // optional: depends on Material defaults
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.dialog-close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}

--- a/frontend/src/app/shared/dialogs/confirm-dialog.html
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.html
@@ -1,7 +1,7 @@
 <div  class="dialog-titlebar">
   <h2 mat-dialog-title class="dialog-title">{{titleKey | translate:titleParams }}</h2>
 
-  <button mat-icon-button (click)="clickOnCancel()" aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
+  <button type="button" mat-icon-button mat-dialog-close aria-label="{{'shared.aria.closeDialog' | translate}}" class="dialog-close-btn">
     <mat-icon>close</mat-icon>
   </button>
 </div>
@@ -11,7 +11,7 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button matButton (click)="clickOnCancel()">{{cancelButtonLabel | translate}}</button>
+  <button matButton type="button" mat-dialog-close>{{cancelButtonLabel | translate}}</button>
   <button
     matButton (click)="clickOnConfirm()"
     cdkFocusInitial

--- a/frontend/src/app/shared/dialogs/confirm-dialog.scss
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.scss
@@ -1,17 +1,1 @@
-.dialog-titlebar {
-  position: relative;
-}
-
-/* Keep Material title styling, just reserve space for the close button */
-.dialog-title {
-  padding-right: 56px; // space for close button + margin
-  margin: 0;           // optional: depends on Material defaults
-  white-space: normal;
-  overflow-wrap: anywhere;
-}
-
-.dialog-close-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-}
+@use './common' as *;

--- a/frontend/src/app/shared/dialogs/confirm-dialog.spec.ts
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.spec.ts
@@ -51,16 +51,20 @@ describe('ConfirmDialog', () => {
     expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
   });
 
-  it('should click on cancel button return undefined', () => {
-    const { component } = createComponent({
+  it('should click on cancel button return empty string', () => {
+    const { fixture } = createComponent({
       titleKey: 'Dialog title',
       messageKey: 'Dialog message',
     } satisfies ConfirmDialogData);
 
-    component.clickOnCancel();
+    const cancelButton = fixture.nativeElement.querySelector(
+      'mat-dialog-actions button[mat-dialog-close]'
+    ) as HTMLButtonElement | null;
+
+    cancelButton?.click();
 
     expect(dialogRefSpy.close).toHaveBeenCalledTimes(1);
-    expect(dialogRefSpy.close).toHaveBeenCalledWith();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith('');
   });
 
   function createComponent(data?: ConfirmDialogData) {

--- a/frontend/src/app/shared/dialogs/confirm-dialog.ts
+++ b/frontend/src/app/shared/dialogs/confirm-dialog.ts
@@ -1,6 +1,6 @@
 import { Component, inject } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
-import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
+import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogModule, MatDialogRef, MatDialogTitle } from "@angular/material/dialog";
 import { MatIconModule } from "@angular/material/icon";
 import { ConfirmDialogData } from "./confirm-dialog.types";
 import { TranslatePipe } from "../i18n/translate.pipe";
@@ -11,6 +11,7 @@ import { TranslatePipe } from "../i18n/translate.pipe";
   styleUrl: 'confirm-dialog.scss',
   standalone: true,
   imports: [
+    MatDialogModule,
     MatButtonModule,
     MatIconModule,
     MatDialogTitle,
@@ -38,9 +39,5 @@ export class ConfirmDialog {
 
   clickOnConfirm(): void {
     this.dialogRef.close(true);
-  }
-
-  clickOnCancel(): void {
-    this.dialogRef.close();
   }
 }


### PR DESCRIPTION
Fixes #74 

This PR refactors Angular Material dialogs for better consistency and readability.

- Standardizes dialog close buttons using `mat-dialog-close`
- Harmonizes header/actions layout across Project, Task and Confirm dialogs
- Shares common dialog header styles while keeping templates duplicated

No functional changes.