### PR TITLE
Extract shared form validation helpers

### DIFF
--- a/frontend/src/app/pages/login/login.html
+++ b/frontend/src/app/pages/login/login.html
@@ -18,7 +18,7 @@
 
       <input matInput type="email" formControlName="email"/>
 
-      @if (emailCtrl.invalid && (emailCtrl.touched || submitAttempted)) {
+      @if ( shouldShowError(emailCtrl, submitAttempted) ) {
         <mat-error>
           @if (emailCtrl.hasError('required')) {
             <span>{{ 'auth.login.validation.emailRequired' | translate }}</span>
@@ -34,7 +34,7 @@
       <mat-label>{{ 'auth.login.label.password' | translate }}</mat-label>
       <input matInput type="password" formControlName="password"/>
 
-      @if (passwordCtrl.invalid && (passwordCtrl.touched || submitAttempted)) {
+      @if ( shouldShowError(passwordCtrl, submitAttempted) ) {
         <mat-error>
           {{ 'auth.login.validation.passwordRequired' | translate }}
         </mat-error>

--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, inject, ViewChild } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { Auth } from '../../services/auth';
@@ -8,6 +8,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCardModule } from '@angular/material/card';
 import { UiTextService } from '../../shared/i18n/ui-text.service';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+import { shouldShowError, focusFirstInvalidControl } from '../../shared/forms/form-helpers';
 
 @Component({
   selector: 'app-login',
@@ -19,10 +20,11 @@ export class Login {
   @ViewChild('formEl', { static: true }) private formEl?: ElementRef<HTMLFormElement>;
   error: string | null = null;
   loading = false;
-  readonly router = inject(Router);
-  readonly auth = inject(Auth);
-  readonly formBuilder = inject(FormBuilder);
-  readonly translate = inject(UiTextService);
+  private readonly router = inject(Router);
+  private readonly auth = inject(Auth);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly translate = inject(UiTextService);
+  readonly shouldShowError = shouldShowError;
 
   submitAttempted = false;
 
@@ -45,7 +47,7 @@ export class Login {
     this.form.markAllAsTouched();
 
     if (this.form.invalid) {
-      this.focusFirstInvalidControl();
+      focusFirstInvalidControl(this.form, this.formEl?.nativeElement);
       return;
     }
 
@@ -63,15 +65,5 @@ export class Login {
         this.error = this.translate.t('auth.login.error.invalidCredentials');
       },
     });
-  }
-
-  private focusFirstInvalidControl(): void {
-    const invalidControlName = Object.keys(this.form.controls)
-      .find((name) => this.form.controls[name as keyof typeof this.form.controls].invalid);
-
-    if (!invalidControlName) return;
-
-    const el = this.formEl?.nativeElement.querySelector<HTMLElement>(`[formControlName="${invalidControlName}"]`);
-    el?.focus();
   }
 }

--- a/frontend/src/app/pages/project-detail/task-dialog.html
+++ b/frontend/src/app/pages/project-detail/task-dialog.html
@@ -12,7 +12,7 @@
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>{{ 'tasks.dialog.field.title' | translate }}</mat-label>
       <input matInput formControlName="title" cdkFocusInitial/>
-      @if (titleCtrl.invalid && (titleCtrl.touched || submitAttempted)) {
+      @if ( shouldShowError(titleCtrl, submitAttempted) ) {
         <mat-error>{{ 'tasks.validation.titleRequired' | translate }}</mat-error>
       }
     </mat-form-field>

--- a/frontend/src/app/pages/project-detail/task-dialog.ts
+++ b/frontend/src/app/pages/project-detail/task-dialog.ts
@@ -12,6 +12,7 @@ import { TaskDialogData, TaskDialogResult } from './task-dialog.types';
 import { toIsoLocalDateString } from "../../shared/functions/date";
 import { UiTextService } from "../../shared/i18n/ui-text.service";
 import { TranslatePipe } from "../../shared/i18n/translate.pipe";
+import { shouldShowError, focusFirstInvalidControl } from "../../shared/forms/form-helpers";
 
 @Component({
   selector: 'task-dialog',
@@ -39,6 +40,7 @@ export class TaskDialog implements OnInit {
   private readonly data = inject<TaskDialogData>(MAT_DIALOG_DATA);
   private readonly formBuilder = inject(FormBuilder);
   private readonly translate = inject(UiTextService);
+  readonly shouldShowError = shouldShowError;
 
   submitAttempted = false;
 
@@ -76,7 +78,7 @@ export class TaskDialog implements OnInit {
     this.form.markAllAsTouched();
 
     if (this.form.invalid) {
-      this.focusFirstInvalidControl();
+      focusFirstInvalidControl(this.form, this.formEl?.nativeElement);
       return;
     }
 
@@ -103,16 +105,6 @@ export class TaskDialog implements OnInit {
       status: task.status,
       dueDate: task.dueDate ?? new Date(),
     });
-  }
-
-  private focusFirstInvalidControl(): void {
-    const invalidControlName = Object.keys(this.form.controls)
-      .find((name) => this.form.controls[name as keyof typeof this.form.controls].invalid);
-
-    if (!invalidControlName) return;
-
-    const el = this.formEl?.nativeElement.querySelector<HTMLElement>(`[formControlName="${invalidControlName}"]`);
-    el?.focus();
   }
 }
 

--- a/frontend/src/app/pages/projects/project-dialog.html
+++ b/frontend/src/app/pages/projects/project-dialog.html
@@ -12,7 +12,7 @@
     <mat-form-field class="full-width">
       <mat-label>{{ 'projects.dialog.field.name' | translate }}</mat-label>
       <input matInput formControlName="name" cdkFocusInitial/>
-      @if (nameCtrl.invalid && (nameCtrl.touched || submitAttempted)) {
+      @if ( shouldShowError(nameCtrl, submitAttempted) ) {
         <mat-error>{{ 'projects.validation.nameRequired' | translate }}</mat-error>
       }
     </mat-form-field>

--- a/frontend/src/app/pages/projects/project-dialog.ts
+++ b/frontend/src/app/pages/projects/project-dialog.ts
@@ -15,6 +15,7 @@ import { CreateProjectRequest, Project } from '../../services/projects';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ProjectDialogData, ProjectDialogResult } from './project-dialog.types';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+import { shouldShowError, focusFirstInvalidControl } from '../../shared/forms/form-helpers';
 
 @Component({
   selector: 'project-dialog',
@@ -39,6 +40,7 @@ export class ProjectDialog implements OnInit {
   private readonly dialogRef = inject(MatDialogRef<ProjectDialog>);
   private readonly data = inject<ProjectDialogData>(MAT_DIALOG_DATA);
   private readonly formBuilder = inject(FormBuilder);
+  readonly shouldShowError = shouldShowError;
 
   submitAttempted = false;
 
@@ -74,7 +76,7 @@ export class ProjectDialog implements OnInit {
     this.form.markAllAsTouched();
 
     if (this.form.invalid) {
-      this.focusFirstInvalidControl();
+      focusFirstInvalidControl(this.form, this.formEl?.nativeElement);
       return;
     }
 
@@ -97,16 +99,6 @@ export class ProjectDialog implements OnInit {
       name: project.name,
       description: project.description ?? '',
     });
-  }
-
-  private focusFirstInvalidControl(): void {
-    const invalidControlName = Object.keys(this.form.controls)
-      .find((name) => this.form.controls[name as keyof typeof this.form.controls].invalid);
-
-    if (!invalidControlName) return;
-
-    const el = this.formEl?.nativeElement.querySelector<HTMLElement>(`[formControlName="${invalidControlName}"]`);
-    el?.focus();
   }
 }
 

--- a/frontend/src/app/shared/forms/form-helpers.ts
+++ b/frontend/src/app/shared/forms/form-helpers.ts
@@ -1,0 +1,19 @@
+import { AbstractControl, FormGroup } from "@angular/forms";
+
+export function shouldShowError(control: AbstractControl | null | undefined, submitAttempted: boolean): boolean {
+  return !!control && control.invalid && (control.touched || submitAttempted);
+}
+
+export function focusFirstInvalidControl(form: FormGroup, root: HTMLElement | null | undefined): void {
+  if (!root) return;
+
+  const invalidControlName = Object.keys(form.controls)
+    .find((name) => form.controls[name as keyof typeof form.controls].invalid);
+
+
+  if (!invalidControlName) return;
+
+  const el = root.querySelector<HTMLElement>(`[formControlName="${invalidControlName}"]`);
+
+  el?.focus();
+}


### PR DESCRIPTION
Fixes #75

This PR improves Angular form maintainability by reducing duplicated validation logic.

- Introduces shared helpers for error visibility (`invalid && (touched || submitAttempted)`)
- Shares a common `focusFirstInvalidControl()` utility across forms
- Updates Login, ProjectDialog and TaskDialog to use the new helpers

No functional changes.