### PR TITLE
Also trigger matomo tracking on backend home page

### DIFF
--- a/backend/src/main/java/fr/manooweb/backend/config/SwaggerUiMatomoConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SwaggerUiMatomoConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.resource.TransformedResource;
 @Component
 public class SwaggerUiMatomoConfig implements BeanPostProcessor {
 
+  private static final String COMMON_JS_PATH = "/js/matomo-common.js";
   private static final String CUSTOM_JS_PATH = "/js/matomo-swagger.js";
 
   @Override
@@ -51,12 +52,18 @@ public class SwaggerUiMatomoConfig implements BeanPostProcessor {
         }
 
         // Avoid double injection
-        if (html.contains(CUSTOM_JS_PATH)) {
+        if (html.contains(COMMON_JS_PATH) || html.contains(CUSTOM_JS_PATH)) {
           return transformed;
         }
 
-        String tag = "<script src=\"" + CUSTOM_JS_PATH + "\" defer></script>";
-        String updated = html.replace("</body>", tag + "\n</body>");
+        String tags =
+            "<script src=\""
+                + COMMON_JS_PATH
+                + "\" defer></script>\n"
+                + "<script src=\""
+                + CUSTOM_JS_PATH
+                + "\" defer></script>";
+        String updated = html.replace("</body>", tags + "\n</body>");
 
         return new TransformedResource(transformed, updated.getBytes(StandardCharsets.UTF_8));
       }

--- a/backend/src/main/resources/static/js/matomo-common.js
+++ b/backend/src/main/resources/static/js/matomo-common.js
@@ -1,0 +1,21 @@
+(function () {
+  const _paq = (globalThis._paq = globalThis._paq || []);
+  _paq.push(
+    ['disableCookies'],
+    ['setDoNotTrack', true],
+    ['HeatmapSessionRecording::disable'],
+    ['enableLinkTracking'],
+    ['trackPageView'],
+  );
+
+  const u = 'https://stats.manooweb.fr/';
+  _paq.push(['setTrackerUrl', u + 'matomo.php'], ['setSiteId', '3']);
+
+  const d = document;
+  const g = d.createElement('script');
+  const s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.defer = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();

--- a/backend/src/main/resources/static/js/matomo-swagger.js
+++ b/backend/src/main/resources/static/js/matomo-swagger.js
@@ -1,27 +1,3 @@
-(function () {
-  const _paq = (globalThis._paq = globalThis._paq || []);
-  _paq.push(
-    ['disableCookies'],
-    ['setDoNotTrack', true],
-    ['HeatmapSessionRecording::disable'],
-    ['enableLinkTracking'],
-    ['trackPageView']);
-
-  (function () {
-    const u = 'https://stats.manooweb.fr/';
-    _paq.push(
-      ['setTrackerUrl', u + 'matomo.php'],
-      ['setSiteId', '3']);
-    const d = document;
-    const g = d.createElement('script');
-    const s = d.getElementsByTagName('script')[0];
-    g.async = true;
-    g.defer = true;
-    g.src = u + 'matomo.js';
-    s.parentNode.insertBefore(g, s);
-  })();
-})();
-
 // Inject styles to make the "API home" link in the Swagger description more visible and look like a proper navigation link.
 (function () {
   const style = document.createElement('style');

--- a/backend/src/main/resources/templates/home.html
+++ b/backend/src/main/resources/templates/home.html
@@ -30,6 +30,7 @@
                 <a class="btn" href="/api/v1/health" target="_blank" rel="noopener noreferrer">View health endpoint</a>
             </div>
 
+            <script src="/js/matomo-common.js"></script>
             <script src="/js/home.js"></script>
         </section>
     </main>


### PR DESCRIPTION
Simply also add matomo tracking on backend home page (not only on swagger ui as at the beginning)