### PR TITLE
Refactor authentication

### DIFF
--- a/.github/workflows/api-e2e-bruno.yml
+++ b/.github/workflows/api-e2e-bruno.yml
@@ -71,7 +71,7 @@ jobs:
           PGPASSWORD: demo
           APP_USER_NAME: demo@example.com
           APP_USER_PASSWORD: demo
-          APP_SECURITY_JWT_ISSUER: http://localhost:8080
+          APP_SECURITY_JWT_ISSUER: https://localhost:8443
           APP_SECURITY_JWT_SECRET: ci-test-secret-at-least-32-characters
         run: |
           nohup ./backend/mvnw -f backend -q spring-boot:run > springboot.log 2>&1 &
@@ -80,7 +80,7 @@ jobs:
       - name: Wait for API health endpoint
         run: |
           for i in {1..40}; do
-            if curl -fsS http://localhost:8080/api/v1/health > /dev/null; then
+            if curl -k -fsS https://localhost:8443/api/v1/health > /dev/null; then
               echo "API is up"
               exit 0
             fi
@@ -96,7 +96,7 @@ jobs:
         run: npm ci
 
       - name: Run Bruno E2E tests
-        run: npm run test:api
+        run: npm run test:ci:api
 
       - name: Show Spring Boot logs on failure
         if: failure()

--- a/.github/workflows/api-e2e-bruno.yml
+++ b/.github/workflows/api-e2e-bruno.yml
@@ -61,9 +61,23 @@ jobs:
       - name: Backend - build (skip tests)
         run: ./backend/mvnw -f backend -DskipTests package
 
-      - name: Backend - start app (dev profile)
+      - name: Generate CI TLS keystore
+        run: |
+          mkdir -p backend/target/certs
+          keytool -genkeypair \
+            -alias springboot-ci \
+            -keyalg RSA \
+            -keysize 2048 \
+            -storetype PKCS12 \
+            -keystore backend/target/certs/springboot-ci.p12 \
+            -storepass changeit \
+            -validity 1 \
+            -dname "CN=localhost, OU=CI, O=Manooweb, L=CI, ST=CI, C=FR" \
+            -ext "SAN=dns:localhost,ip:127.0.0.1"
+
+      - name: Backend - start app (ci profile)
         env:
-          SPRING_PROFILES_ACTIVE: dev
+          SPRING_PROFILES_ACTIVE: ci
           PGHOST: localhost
           PGPORT: 5432
           PGDATABASE: demo
@@ -73,6 +87,8 @@ jobs:
           APP_USER_PASSWORD: demo
           APP_SECURITY_JWT_ISSUER: https://localhost:8443
           APP_SECURITY_JWT_SECRET: ci-test-secret-at-least-32-characters
+          APP_SSL_KEY_STORE: ${{ github.workspace }}/backend/target/certs/springboot-ci.p12
+          APP_SSL_KEY_STORE_PASSWORD: changeit
         run: |
           nohup ./backend/mvnw -f backend -q spring-boot:run > springboot.log 2>&1 &
           echo $! > springboot.pid

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Java code formatting is enforced using Spotless.
 Verify formatting:
 
 ```bash
-./backend/mvnw -f backend clean verify
+./backend/mvnw -f backend spotless:check
 ```
 
 Fix formatting:

--- a/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
+++ b/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
@@ -1,16 +1,19 @@
 package fr.manooweb.backend.api.controller;
 
 import fr.manooweb.backend.api.dto.auth.AuthLoginRequest;
-import fr.manooweb.backend.api.dto.auth.AuthTokenResponse;
 import fr.manooweb.backend.security.JwtTokenService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@ResponseStatus(HttpStatus.OK)
 public class AuthController {
 
   private final AuthenticationManager authenticationManager;
@@ -23,13 +26,22 @@ public class AuthController {
 
   @PostMapping("/login")
   @ResponseStatus(HttpStatus.OK)
-  public AuthTokenResponse login(@Valid @RequestBody AuthLoginRequest request) {
+  public ResponseEntity<Void> login(@Valid @RequestBody AuthLoginRequest request) {
     // Authenticate username/password against the configured UserDetailsService.
     authenticationManager.authenticate(
         new UsernamePasswordAuthenticationToken(request.username(), request.password()));
 
     String token = tokenService.generateToken(request.username());
 
-    return new AuthTokenResponse("Bearer", token, tokenService.getTtlSeconds());
+    ResponseCookie cookie =
+        ResponseCookie.from("auth_token", token)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(tokenService.getTtlSeconds())
+            .build();
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
   }
 }

--- a/backend/src/main/java/fr/manooweb/backend/api/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/fr/manooweb/backend/api/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -118,6 +119,21 @@ public class GlobalExceptionHandler {
             List.of());
 
     return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ApiErrorResponse> handleAuthentication(
+      AuthenticationException ex, HttpServletRequest request) {
+    ApiErrorResponse body =
+        new ApiErrorResponse(
+            OffsetDateTime.now(),
+            HttpStatus.UNAUTHORIZED.value(),
+            HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+            "Invalid credentials",
+            request.getRequestURI(),
+            List.of());
+
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
   }
 
   @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/fr/manooweb/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/OpenApiConfig.java
@@ -1,17 +1,12 @@
 package fr.manooweb.backend.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
-
-  private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
   @Bean
   public OpenAPI backendOpenApi() {
@@ -21,24 +16,10 @@ public class OpenApiConfig {
                 .title("Spring Boot REST API Demo")
                 .description(
                     """
-                                                                Demo API.
+                  Demo API.
 
-                                                                <a href="/" target="_self">🏠 API home</a>
-                                                                """)
-                .version("v0"))
-        // Register the Bearer JWT scheme so Swagger UI can show the "Authorize" button.
-        .components(
-            new Components()
-                .addSecuritySchemes(
-                    SECURITY_SCHEME_NAME,
-                    new SecurityScheme()
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("bearer")
-                        // JWT is the standard for Bearer tokens here
-                        // (Authorization: Bearer <token>).
-                        .bearerFormat("JWT")))
-        // Apply the scheme globally so secured endpoints require Authorization header
-        // in Swagger.
-        .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
+                  <a href="/" target="_self">🏠 API home</a>
+                  """)
+                .version("v0"));
   }
 }

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -1,10 +1,10 @@
 package fr.manooweb.backend.config;
 
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,15 +22,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import com.nimbusds.jose.jwk.source.ImmutableSecret;
-
-import jakarta.servlet.http.Cookie;
 
 @Configuration
 @EnableWebSecurity
@@ -73,9 +70,11 @@ public class SecurityConfig {
   }
 
   @Bean
-  public JwtDecoder jwtDecoder() {
+  public JwtDecoder jwtDecoder(@Value("${app.security.jwt.issuer}") String issuer) {
     // HMAC SHA-256 decoder using a symmetric secret.
-    return NimbusJwtDecoder.withSecretKey(hmacKey()).build();
+    NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(hmacKey()).build();
+    decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(issuer));
+    return decoder;
   }
 
   @Bean
@@ -105,6 +104,11 @@ public class SecurityConfig {
   private SecretKey hmacKey() {
     // For HMAC, the secret should be at least 32 bytes for HS256.
     byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+
+    if (keyBytes.length < 32) {
+      throw new IllegalStateException("JWT secret must be at least 32 bytes for HS256");
+    }
+
     return new SecretKeySpec(keyBytes, "HmacSHA256");
   }
 
@@ -125,9 +129,9 @@ public class SecurityConfig {
         .httpBasic(basic -> basic.disable())
 
         // Enable JWT Bearer token authentication (Authorization: Bearer <token>).
-        .oauth2ResourceServer(oauth2 -> oauth2
-          .bearerTokenResolver(bearerTokenResolver())
-          .jwt(Customizer.withDefaults()))
+        .oauth2ResourceServer(
+            oauth2 ->
+                oauth2.bearerTokenResolver(bearerTokenResolver()).jwt(Customizer.withDefaults()))
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -2,7 +2,10 @@ package fr.manooweb.backend.config;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 
+import fr.manooweb.backend.security.CsrfCookieFilter;
 import fr.manooweb.backend.security.JwtCookieAuthenticationFilter;
+import fr.manooweb.backend.security.SpaCsrfTokenRequestHandler;
+
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -100,6 +103,11 @@ public class SecurityConfig {
   }
 
   @Bean
+  public CsrfCookieFilter crsfCookieFilter() {
+    return new CsrfCookieFilter();
+  }
+
+  @Bean
   public RequestMatcher csrfProtectionMatcher() {
     return new AndRequestMatcher(
         CsrfFilter.DEFAULT_CSRF_MATCHER,
@@ -119,7 +127,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter, CsrfCookieFilter csrfCookieFilter) throws Exception {
     http
         // Stateless API: do not create HTTP sessions.
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -131,6 +139,7 @@ public class SecurityConfig {
         .csrf(
             csrf ->
               csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                  .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()) 
                   .requireCsrfProtectionMatcher(csrfProtectionMatcher()))
 
         // Enable HTTP Basic authentication (handy for quick testing).
@@ -139,6 +148,7 @@ public class SecurityConfig {
 
         // Enable cookie-based JWT authentication.
         .addFilterBefore(jwtCookieAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(csrfCookieFilter, CsrfFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -1,11 +1,9 @@
 package fr.manooweb.backend.config;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
-
 import fr.manooweb.backend.security.CsrfCookieFilter;
 import fr.manooweb.backend.security.JwtCookieAuthenticationFilter;
 import fr.manooweb.backend.security.SpaCsrfTokenRequestHandler;
-
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -55,8 +53,7 @@ public class SecurityConfig {
   @Value("${app.security.jwt.issuer}")
   private String jwtIssuer;
 
-
- // Password hashing strategy used for encoding in-memory user passwords.
+  // Password hashing strategy used for encoding in-memory user passwords.
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
@@ -111,8 +108,7 @@ public class SecurityConfig {
   public RequestMatcher csrfProtectionMatcher() {
     return new AndRequestMatcher(
         CsrfFilter.DEFAULT_CSRF_MATCHER,
-        new NegatedRequestMatcher(new AntPathRequestMatcher("/api/v1/auth/login", "POST"))
-    );
+        new NegatedRequestMatcher(new AntPathRequestMatcher("/api/v1/auth/login", "POST")));
   }
 
   private SecretKey hmacKey() {
@@ -127,7 +123,11 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter, CsrfCookieFilter csrfCookieFilter) throws Exception {
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity http,
+      JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter,
+      CsrfCookieFilter csrfCookieFilter)
+      throws Exception {
     http
         // Stateless API: do not create HTTP sessions.
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -138,9 +138,9 @@ public class SecurityConfig {
         // Enable CSRF protection because of using cookies for JWT authentication.
         .csrf(
             csrf ->
-              csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                  .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()) 
-                  .requireCsrfProtectionMatcher(csrfProtectionMatcher()))
+                csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
+                    .requireCsrfProtectionMatcher(csrfProtectionMatcher()))
 
         // Enable HTTP Basic authentication (handy for quick testing).
         // Note: if you access endpoints via browser, Spring may also show a login page.

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package fr.manooweb.backend.config;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
-import jakarta.servlet.http.Cookie;
+
+import fr.manooweb.backend.security.JwtCookieAuthenticationFilter;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -25,9 +26,15 @@ import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
-import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -42,7 +49,11 @@ public class SecurityConfig {
   @Value("${APP_USER_PASSWORD}")
   private String demoPassword;
 
-  // Password hashing strategy used for encoding in-memory user passwords.
+  @Value("${app.security.jwt.issuer}")
+  private String jwtIssuer;
+
+
+ // Password hashing strategy used for encoding in-memory user passwords.
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
@@ -70,10 +81,10 @@ public class SecurityConfig {
   }
 
   @Bean
-  public JwtDecoder jwtDecoder(@Value("${app.security.jwt.issuer}") String issuer) {
+  public JwtDecoder jwtDecoder() {
     // HMAC SHA-256 decoder using a symmetric secret.
     NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(hmacKey()).build();
-    decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(issuer));
+    decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(jwtIssuer));
     return decoder;
   }
 
@@ -84,21 +95,16 @@ public class SecurityConfig {
   }
 
   @Bean
-  public BearerTokenResolver bearerTokenResolver() {
-    return request -> {
-      Cookie[] cookies = request.getCookies();
-      if (cookies == null) {
-        return null;
-      }
+  public JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter(JwtDecoder jwtDecoder) {
+    return new JwtCookieAuthenticationFilter(jwtDecoder);
+  }
 
-      for (Cookie cookie : cookies) {
-        if ("auth_token".equals(cookie.getName())) {
-          return cookie.getValue();
-        }
-      }
-
-      return null;
-    };
+  @Bean
+  public RequestMatcher csrfProtectionMatcher() {
+    return new AndRequestMatcher(
+        CsrfFilter.DEFAULT_CSRF_MATCHER,
+        new NegatedRequestMatcher(new AntPathRequestMatcher("/api/v1/auth/login", "POST"))
+    );
   }
 
   private SecretKey hmacKey() {
@@ -113,7 +119,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter) throws Exception {
     http
         // Stateless API: do not create HTTP sessions.
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -121,17 +127,18 @@ public class SecurityConfig {
         // Enable CORS support and delegate configuration to CorsConfigurationSource
         .cors(Customizer.withDefaults())
 
-        // Disable CSRF protection since we are not using cookies for authentication.
-        .csrf(csrf -> csrf.disable())
+        // Enable CSRF protection because of using cookies for JWT authentication.
+        .csrf(
+            csrf ->
+              csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                  .requireCsrfProtectionMatcher(csrfProtectionMatcher()))
 
         // Enable HTTP Basic authentication (handy for quick testing).
         // Note: if you access endpoints via browser, Spring may also show a login page.
         .httpBasic(basic -> basic.disable())
 
-        // Enable JWT Bearer token authentication (Authorization: Bearer <token>).
-        .oauth2ResourceServer(
-            oauth2 ->
-                oauth2.bearerTokenResolver(bearerTokenResolver()).jwt(Customizer.withDefaults()))
+        // Enable cookie-based JWT authentication.
+        .addFilterBefore(jwtCookieAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -1,9 +1,10 @@
 package fr.manooweb.backend.config;
 
-import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import java.nio.charset.StandardCharsets;
+
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,8 +24,13 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+
+import jakarta.servlet.http.Cookie;
 
 @Configuration
 @EnableWebSecurity
@@ -78,6 +84,24 @@ public class SecurityConfig {
     return new NimbusJwtEncoder(new ImmutableSecret<>(hmacKey()));
   }
 
+  @Bean
+  public BearerTokenResolver bearerTokenResolver() {
+    return request -> {
+      Cookie[] cookies = request.getCookies();
+      if (cookies == null) {
+        return null;
+      }
+
+      for (Cookie cookie : cookies) {
+        if ("auth_token".equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+
+      return null;
+    };
+  }
+
   private SecretKey hmacKey() {
     // For HMAC, the secret should be at least 32 bytes for HS256.
     byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
@@ -101,7 +125,9 @@ public class SecurityConfig {
         .httpBasic(basic -> basic.disable())
 
         // Enable JWT Bearer token authentication (Authorization: Bearer <token>).
-        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+        .oauth2ResourceServer(oauth2 -> oauth2
+          .bearerTokenResolver(bearerTokenResolver())
+          .jwt(Customizer.withDefaults()))
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -106,6 +106,8 @@ public class SecurityConfig {
 
   @Bean
   public RequestMatcher csrfProtectionMatcher() {
+    // Login is the only unsafe endpoint excluded from CSRF because it bootstraps
+    // the authentication and CSRF cookies. Mutating authenticated endpoints remain protected.
     return new AndRequestMatcher(
         CsrfFilter.DEFAULT_CSRF_MATCHER,
         new NegatedRequestMatcher(
@@ -138,6 +140,8 @@ public class SecurityConfig {
         .cors(Customizer.withDefaults())
 
         // Enable CSRF protection because of using cookies for JWT authentication.
+        // The CSRF cookie must be readable by SPA clients so they can echo it in the
+        // X-XSRF-TOKEN header. The JWT auth cookie remains HttpOnly.
         .csrf(
             csrf ->
                 csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -32,8 +32,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.AndRequestMatcher;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -108,7 +108,9 @@ public class SecurityConfig {
   public RequestMatcher csrfProtectionMatcher() {
     return new AndRequestMatcher(
         CsrfFilter.DEFAULT_CSRF_MATCHER,
-        new NegatedRequestMatcher(new AntPathRequestMatcher("/api/v1/auth/login", "POST")));
+        new NegatedRequestMatcher(
+            PathPatternRequestMatcher.withDefaults()
+                .matcher(HttpMethod.POST, "/api/v1/auth/login")));
   }
 
   private SecretKey hmacKey() {

--- a/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
@@ -1,18 +1,17 @@
 package fr.manooweb.backend.security;
 
-import java.io.IOException;
-
-import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 public class CsrfCookieFilter extends OncePerRequestFilter {
   @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
     if (csrfToken != null) {

--- a/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
@@ -5,13 +5,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.lang.NonNull;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 public class CsrfCookieFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
       throws ServletException, IOException {
     CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
     if (csrfToken != null) {

--- a/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/CsrfCookieFilter.java
@@ -1,0 +1,23 @@
+package fr.manooweb.backend.security;
+
+import java.io.IOException;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CsrfCookieFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+    if (csrfToken != null) {
+      csrfToken.getToken();
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
@@ -1,0 +1,92 @@
+package fr.manooweb.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtCookieAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String AUTH_COOKIE_NAME = "auth_token";
+
+  private final JwtDecoder jwtDecoder;
+
+  public JwtCookieAuthenticationFilter(JwtDecoder jwtDecoder) {
+    this.jwtDecoder = jwtDecoder;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      String token = extractTokenFromCookie(request);
+
+      if (token != null) {
+        try {
+          Jwt jwt = jwtDecoder.decode(token);
+          JwtAuthenticationToken authentication =
+              new JwtAuthenticationToken(jwt, extractAuthorities(jwt), jwt.getSubject());
+          authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+          SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (JwtException ex) {
+          SecurityContextHolder.clearContext();
+        }
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String extractTokenFromCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+
+    for (Cookie cookie : cookies) {
+      if (AUTH_COOKIE_NAME.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+
+    return null;
+  }
+
+  private List<GrantedAuthority> extractAuthorities(Jwt jwt) {
+    Object rolesClaim = jwt.getClaim("roles");
+
+    if (rolesClaim instanceof String role) {
+      return List.of(toRoleAuthority(role));
+    }
+
+    if (rolesClaim instanceof Collection<?> roles) {
+      return roles.stream()
+          .filter(String.class::isInstance)
+          .map(String.class::cast)
+          .map(this::toRoleAuthority)
+          .map(GrantedAuthority.class::cast)
+          .toList();
+    }
+
+    return List.of();
+  }
+
+  private SimpleGrantedAuthority toRoleAuthority(String role) {
+    String normalizedRole = role.startsWith("ROLE_") ? role : "ROLE_" + role;
+    return new SimpleGrantedAuthority(normalizedRole);
+  }
+}

--- a/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -30,7 +31,9 @@ public class JwtCookieAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
       throws ServletException, IOException {
     if (SecurityContextHolder.getContext().getAuthentication() == null) {
       String token = extractTokenFromCookie(request);

--- a/backend/src/main/java/fr/manooweb/backend/security/SpaCsrfTokenRequestHandler.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/SpaCsrfTokenRequestHandler.java
@@ -1,0 +1,30 @@
+package fr.manooweb.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.function.Supplier;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
+
+public final class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
+
+  private final CsrfTokenRequestHandler plain = new CsrfTokenRequestAttributeHandler();
+  private final CsrfTokenRequestHandler xor = new XorCsrfTokenRequestAttributeHandler();
+
+  @Override
+  public void handle(
+      HttpServletRequest request, HttpServletResponse response, Supplier<CsrfToken> csrfToken) {
+    xor.handle(request, response, csrfToken);
+    csrfToken.get();
+  }
+
+  @Override
+  public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+    String headerValue = request.getHeader(csrfToken.getHeaderName());
+    return (StringUtils.hasText(headerValue) ? plain : xor)
+        .resolveCsrfTokenValue(request, csrfToken);
+  }
+}

--- a/backend/src/main/resources/application-ci.yaml
+++ b/backend/src/main/resources/application-ci.yaml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}
+    username: ${PGUSER}
+    password: ${PGPASSWORD}
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+
+  flyway:
+    enabled: true
+
+server:
+  port: 8443
+  ssl:
+    enabled: true
+    key-store: file:${APP_SSL_KEY_STORE}
+    key-store-password: ${APP_SSL_KEY_STORE_PASSWORD}
+    key-store-type: PKCS12
+    key-alias: springboot-ci
+
+app:
+  cors:
+    allowed-origins:
+      - "https://localhost:4200"
+

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -15,6 +15,11 @@ spring:
   flyway:
     enabled: true
 
+springdoc:
+  swagger-ui:
+    csrf:
+      enabled: true
+
 server:
   port: 8443
   ssl:

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -15,8 +15,17 @@ spring:
   flyway:
     enabled: true
 
+server:
+  port: 8443
+  ssl:
+    enabled: true
+    key-store: file:/home/manu/Documents/Projets-info/remise-a-niveau-java/springboot-rest-api-demo-cert/localhost+3.p12
+    key-store-password: changeit
+    key-store-type: PKCS12
+    key-alias: springboot-dev
+
 app:
   cors:
     allowed-origins:
-      - "http://localhost:4200"
-      - "http://192.168.1.168:4200"
+      - "https://localhost:4200"
+      - "https://192.168.1.168:4200"

--- a/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
@@ -47,8 +47,13 @@ class AuthIntegrationTest {
             .andExpect(cookie().secure(AUTH_COOKIE_NAME, true))
             .andReturn();
 
-    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
-    assertThat(setCookie).contains("SameSite=Strict");
+    String authSetCookie =
+        result.getResponse().getHeaders(HttpHeaders.SET_COOKIE).stream()
+            .filter(header -> header.startsWith(AUTH_COOKIE_NAME + "="))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(authSetCookie).contains("SameSite=Strict");
   }
 
   @Test

--- a/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
@@ -1,0 +1,122 @@
+package fr.manooweb.backend.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthIntegrationTest {
+
+  private static final String AUTH_COOKIE_NAME = "auth_token";
+
+  @Autowired MockMvc mockMvc;
+
+  @Test
+  void login_withValidCredentials_ShouldSetAuthCookie() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "username": "test@example.com",
+                          "password": "test-password"
+                        }
+                        """))
+            .andExpect(status().isOk())
+            .andExpect(cookie().exists(AUTH_COOKIE_NAME))
+            .andExpect(cookie().httpOnly(AUTH_COOKIE_NAME, true))
+            .andExpect(cookie().secure(AUTH_COOKIE_NAME, true))
+            .andReturn();
+
+    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).contains("SameSite=Strict");
+  }
+
+  @Test
+  void login_withInvalidCredentials_ShouldReturnUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "username": "test@example.com",
+                      "password": "wrong-password"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void login_withInvalidPayload_ShouldReturnBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "username": "",
+                      "password": ""
+                    }
+                    """))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void me_withoutAuthentication_ShouldReturnForbidden() throws Exception {
+    mockMvc.perform(get("/api/v1/me")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void me_withAuthCookie_ShouldReturnCurrentUser() throws Exception {
+    Cookie authCookie = loginAndGetAuthCookie();
+
+    mockMvc
+        .perform(get("/api/v1/me").cookie(authCookie))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.username").value("test@example.com"))
+        .andExpect(jsonPath("$.roles[0]").value("USER"));
+  }
+
+  private Cookie loginAndGetAuthCookie() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "username": "test@example.com",
+                          "password": "test-password"
+                        }
+                        """))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    Cookie authCookie = result.getResponse().getCookie(AUTH_COOKIE_NAME);
+    assertThat(authCookie).isNotNull();
+    return authCookie;
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/api/ProjectCreateIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/ProjectCreateIntegrationTest.java
@@ -1,5 +1,6 @@
 package fr.manooweb.backend.api;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,7 +39,8 @@ class ProjectCreateIntegrationTest {
 
     // Act + Assert
     mockMvc
-        .perform(post("/api/v1/projects").contentType("application/json").content(payload))
+        .perform(
+            post("/api/v1/projects").with(csrf()).contentType("application/json").content(payload))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.name").value("First project"))
         .andExpect(jsonPath("$.description").value("First project created by integration test"));

--- a/backend/src/test/java/fr/manooweb/backend/api/ProjectUpdateIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/ProjectUpdateIntegrationTest.java
@@ -1,5 +1,6 @@
 package fr.manooweb.backend.api;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,6 +38,7 @@ class ProjectUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/projects/{id}", project.getId())
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -61,6 +63,7 @@ class ProjectUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/projects/{id}", projectId)
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -83,6 +86,7 @@ class ProjectUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/projects/{id}", projectId)
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -105,6 +109,7 @@ class ProjectUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/projects/{id}", projectId)
+                .with(csrf())
                 .contentType("application/json")
                 // Trailing comma causes malformed JSON
                 .content(

--- a/backend/src/test/java/fr/manooweb/backend/api/TaskCreateIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/TaskCreateIntegrationTest.java
@@ -1,5 +1,6 @@
 package fr.manooweb.backend.api;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,6 +48,7 @@ class TaskCreateIntegrationTest {
     mockMvc
         .perform(
             post("/api/v1/projects/{projectId}/tasks", project.getId())
+                .with(csrf())
                 .contentType("application/json")
                 .content(payload))
         .andExpect(status().isCreated())
@@ -70,6 +72,7 @@ class TaskCreateIntegrationTest {
     mockMvc
         .perform(
             post("/api/v1/projects/{projectId}/tasks", project.getId())
+                .with(csrf())
                 .contentType("application/json")
                 .content(payload))
         .andExpect(status().isBadRequest())

--- a/backend/src/test/java/fr/manooweb/backend/api/TaskUpdateIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/TaskUpdateIntegrationTest.java
@@ -1,5 +1,6 @@
 package fr.manooweb.backend.api;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,6 +52,7 @@ class TaskUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/tasks/{taskId}", task.getId())
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -80,6 +82,7 @@ class TaskUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/tasks/{taskId}", taskId)
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -104,6 +107,7 @@ class TaskUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/tasks/{taskId}", taskId)
+                .with(csrf())
                 .contentType("application/json")
                 .content(
                     """
@@ -127,6 +131,7 @@ class TaskUpdateIntegrationTest {
     mockMvc
         .perform(
             put("/api/v1/tasks/{taskId}", taskId)
+                .with(csrf())
                 .contentType("application/json")
                 // Trailing comma causes malformed JSON
                 .content(

--- a/backend/src/test/java/fr/manooweb/backend/config/SecurityConfigTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/config/SecurityConfigTest.java
@@ -1,0 +1,28 @@
+package fr.manooweb.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SecurityConfigTest {
+
+  @Test
+  void jwtEncoder_withShortSecret_ShouldFailFast() {
+    SecurityConfig securityConfig = new SecurityConfig();
+    ReflectionTestUtils.setField(securityConfig, "jwtSecret", "too-short");
+
+    assertThatThrownBy(securityConfig::jwtEncoder)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("JWT secret must be at least 32 bytes for HS256");
+  }
+
+  @Test
+  void jwtEncoder_withValidSecret_ShouldCreateEncoder() {
+    SecurityConfig securityConfig = new SecurityConfig();
+    ReflectionTestUtils.setField(securityConfig, "jwtSecret", "test-secret-at-least-32-characters");
+
+    assertThat(securityConfig.jwtEncoder()).isNotNull();
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/security/CsrfCookieFilterTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/security/CsrfCookieFilterTest.java
@@ -1,0 +1,42 @@
+package fr.manooweb.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+
+class CsrfCookieFilterTest {
+
+  @Test
+  void doFilterInternal_withoutCsrfToken_ShouldContinueFilterChain()
+      throws ServletException, IOException {
+    MockFilterChain filterChain = new MockFilterChain();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    new CsrfCookieFilter().doFilterInternal(request, response, filterChain);
+
+    assertThat(filterChain.getRequest()).isSameAs(request);
+    assertThat(filterChain.getResponse()).isSameAs(response);
+  }
+
+  @Test
+  void doFilterInternal_withCsrfToken_ShouldForceTokenResolution()
+      throws ServletException, IOException {
+    CsrfToken csrfToken = mock(CsrfToken.class);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute(CsrfToken.class.getName(), csrfToken);
+
+    new CsrfCookieFilter()
+        .doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    verify(csrfToken).getToken();
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilterTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilterTest.java
@@ -1,0 +1,162 @@
+package fr.manooweb.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+class JwtCookieAuthenticationFilterTest {
+
+  private static final String AUTH_COOKIE_NAME = "auth_token";
+  private static final String TOKEN_VALUE = "jwt-token";
+
+  private JwtDecoder jwtDecoder;
+  private JwtCookieAuthenticationFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    SecurityContextHolder.clearContext();
+    jwtDecoder = mock(JwtDecoder.class);
+    filter = new JwtCookieAuthenticationFilter(jwtDecoder);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void doFilterInternal_whenAlreadyAuthenticated_ShouldNotDecodeJwt()
+      throws ServletException, IOException {
+    Authentication existingAuthentication =
+        new TestingAuthenticationToken("existing-user", "credentials");
+    SecurityContextHolder.getContext().setAuthentication(existingAuthentication);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie(AUTH_COOKIE_NAME, TOKEN_VALUE));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication())
+        .isSameAs(existingAuthentication);
+    verify(jwtDecoder, never()).decode(TOKEN_VALUE);
+  }
+
+  @Test
+  void doFilterInternal_withoutCookies_ShouldContinueWithoutAuthentication()
+      throws ServletException, IOException {
+    filter.doFilterInternal(
+        new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verify(jwtDecoder, never()).decode(TOKEN_VALUE);
+  }
+
+  @Test
+  void doFilterInternal_withoutAuthCookie_ShouldContinueWithoutAuthentication()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie("other_cookie", TOKEN_VALUE));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verify(jwtDecoder, never()).decode(TOKEN_VALUE);
+  }
+
+  @Test
+  void doFilterInternal_withInvalidJwt_ShouldClearAuthentication()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = requestWithAuthCookie();
+    when(jwtDecoder.decode(TOKEN_VALUE)).thenThrow(new BadJwtException("Invalid JWT"));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    verify(jwtDecoder).decode(TOKEN_VALUE);
+  }
+
+  @Test
+  void doFilterInternal_withValidJwtAndStringRole_ShouldAuthenticateRequest()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = requestWithAuthCookie();
+    when(jwtDecoder.decode(TOKEN_VALUE)).thenReturn(jwtWithRoles("USER"));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getName()).isEqualTo("demo@example.com");
+    assertThat(authentication.getAuthorities())
+        .extracting("authority")
+        .containsExactly("ROLE_USER");
+  }
+
+  @Test
+  void doFilterInternal_withValidJwtAndRoleCollection_ShouldAuthenticateRequest()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = requestWithAuthCookie();
+    when(jwtDecoder.decode(TOKEN_VALUE))
+        .thenReturn(jwtWithRoles(List.of("USER", "ROLE_ADMIN", 42)));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getAuthorities())
+        .extracting("authority")
+        .containsExactly("ROLE_USER", "ROLE_ADMIN");
+  }
+
+  @Test
+  void doFilterInternal_withValidJwtAndNoRoles_ShouldAuthenticateWithoutAuthorities()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = requestWithAuthCookie();
+    when(jwtDecoder.decode(TOKEN_VALUE)).thenReturn(jwtWithRoles(null));
+
+    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.getAuthorities()).isEmpty();
+  }
+
+  private MockHttpServletRequest requestWithAuthCookie() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie(AUTH_COOKIE_NAME, TOKEN_VALUE));
+    return request;
+  }
+
+  private Jwt jwtWithRoles(Object roles) {
+    Map<String, Object> claims =
+        roles == null
+            ? Map.of("sub", "demo@example.com")
+            : Map.of("sub", "demo@example.com", "roles", roles);
+
+    return new Jwt(
+        TOKEN_VALUE,
+        Instant.now(),
+        Instant.now().plusSeconds(3600),
+        Map.of("alg", "HS256"),
+        claims);
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/security/SpaCsrfTokenRequestHandlerTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/security/SpaCsrfTokenRequestHandlerTest.java
@@ -1,0 +1,34 @@
+package fr.manooweb.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+class SpaCsrfTokenRequestHandlerTest {
+
+  private static final DefaultCsrfToken CSRF_TOKEN =
+      new DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "csrf-token-value");
+
+  private final SpaCsrfTokenRequestHandler handler = new SpaCsrfTokenRequestHandler();
+
+  @Test
+  void resolveCsrfTokenValue_withHeader_ShouldUsePlainHandler() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(CSRF_TOKEN.getHeaderName(), CSRF_TOKEN.getToken());
+
+    String resolvedToken = handler.resolveCsrfTokenValue(request, CSRF_TOKEN);
+
+    assertThat(resolvedToken).isEqualTo(CSRF_TOKEN.getToken());
+  }
+
+  @Test
+  void resolveCsrfTokenValue_withoutHeader_ShouldUseXorHandler() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    String resolvedToken = handler.resolveCsrfTokenValue(request, CSRF_TOKEN);
+
+    assertThat(resolvedToken).isNull();
+  }
+}

--- a/bruno/backend/Login/Login.bru
+++ b/bruno/backend/Login/Login.bru
@@ -26,11 +26,15 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("response has accessToken", function () {
-    expect(res.body).to.have.property("accessToken");
+  test("auth cookie is returned", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) => cookie.includes("auth_token="));
+    expect(found).to.equal(true);
   });
 
-  test("save token", function () {
-    bru.setEnvVar("token", res.body.accessToken);
+  test("csrf cookie is returned", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) => cookie.includes("XSRF-TOKEN="));
+    expect(found).to.equal(true);
   });
 }

--- a/bruno/backend/collection.bru
+++ b/bruno/backend/collection.bru
@@ -2,14 +2,20 @@ meta {
   name: springboot-rest-api-demo (backend)
 }
 
-auth {
-  mode: bearer
-}
+script:pre-request {
+  const method = req.getMethod();
+  const url = req.getUrl();
 
-auth:bearer {
-  token: {{token}}
-}
+  if (url.includes("/api/v1/auth/login")) {
+    return;
+  }
 
-vars:pre-request {
-  baseUrl: http://localhost:8080
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    const jar = bru.cookies.jar();
+    const csrfCookie = await jar.getCookie(req.getUrl(), "XSRF-TOKEN");
+
+    if (csrfCookie && csrfCookie.value) {
+      req.setHeader("X-XSRF-TOKEN", csrfCookie.value);
+    }
+  }
 }

--- a/bruno/backend/e2e/00_Login.bru
+++ b/bruno/backend/e2e/00_Login.bru
@@ -26,11 +26,15 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("response has accessToken", function () {
-    expect(res.body).to.have.property("accessToken");
+  test("auth cookie is returned", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) => cookie.includes("auth_token="));
+    expect(found).to.equal(true);
   });
 
-  test("save token", function () {
-    bru.setVar("token", res.body.accessToken);
+  test("csrf cookie is returned", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) => cookie.includes("XSRF-TOKEN="));
+    expect(found).to.equal(true);
   });
 }

--- a/bruno/backend/e2e/04_Create Task.bru
+++ b/bruno/backend/e2e/04_Create Task.bru
@@ -23,10 +23,6 @@ body:json {
   }
 }
 
-vars:pre-request {
-  projectId: 8f602828-f8aa-42f8-a643-1ce7cb1368eb
-}
-
 tests {
   test("status is 201", function () {
     expect(res.status).to.equal(201);

--- a/bruno/backend/environments/CI.bru
+++ b/bruno/backend/environments/CI.bru
@@ -1,0 +1,5 @@
+vars {
+  baseUrl: https://localhost:8443
+  projectId:
+  taskId:
+}

--- a/bruno/backend/environments/Test.bru
+++ b/bruno/backend/environments/Test.bru
@@ -1,7 +1,5 @@
 vars {
+  baseUrl: https://192.168.1.168:8443
   projectId: 
   taskId: 
 }
-vars:secret [
-  token
-]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test:api": "cd bruno/backend && npx bru run e2e --env Test --insecure",
-    "test:ci:api": "cd bruno/backend && npx bru run e2e --env Test --insecure"
+    "test:ci:api": "cd bruno/backend && npx bru run e2e --env CI --insecure"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/manooweb/springboot-rest-api-demo/blob/main/LICENSE)",
   "main": "index.js",
   "scripts": {
-    "test:api": "cd bruno/backend && npx bru run e2e"
+    "test:api": "cd bruno/backend && npx bru run e2e --env Test --insecure",
+    "test:ci:api": "cd bruno/backend && npx bru run e2e --env Test --insecure"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #114 

## Summary

This PR improves the JWT authentication flow by moving token transport from frontend-managed Bearer tokens to secure cookies.

### Changes

- Store the JWT in a `Secure`, `HttpOnly`, `SameSite=Strict` cookie.
- Remove Bearer token usage from Swagger UI.
- Add cookie-based JWT authentication on the backend with a dedicated authentication filter.
- Enable CSRF protection because JWT authentication now relies on cookies.
- Add SPA-compatible CSRF handling using an `XSRF-TOKEN` cookie and `X-XSRF-TOKEN` header.
- Make Swagger UI compatible with the production-like cookie + CSRF authentication flow.
- Add HTTPS support for local development and CI-specific configuration.
- Update Bruno API tests to use cookies and CSRF headers.
- Add backend unit and integration tests for the authentication flow.
- Improve authentication error handling so invalid credentials return `401 Unauthorized`.

### Validation

- Backend tests pass.
- Bruno API e2e tests pass with cookie + CSRF authentication.
- SonarCloud Quality Gate passes.
- New-code coverage reaches 100%.






