### PR TITLE
Add logout endpoint

### DIFF
--- a/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
+++ b/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.*;
 @ResponseStatus(HttpStatus.OK)
 public class AuthController {
 
+  private static final String SAME_SITE_STRICT = "Strict";
+
   private final AuthenticationManager authenticationManager;
   private final JwtTokenService tokenService;
 
@@ -37,7 +39,7 @@ public class AuthController {
         ResponseCookie.from("auth_token", token)
             .httpOnly(true)
             .secure(true)
-            .sameSite("Strict")
+            .sameSite(SAME_SITE_STRICT)
             .path("/")
             .maxAge(tokenService.getTtlSeconds())
             .build();
@@ -52,7 +54,7 @@ public class AuthController {
         ResponseCookie.from("auth_token", "")
             .httpOnly(true)
             .secure(true)
-            .sameSite("Strict")
+            .sameSite(SAME_SITE_STRICT)
             .path("/")
             .maxAge(0)
             .build();
@@ -61,7 +63,7 @@ public class AuthController {
         ResponseCookie.from("XSRF-TOKEN", "")
             .httpOnly(false)
             .secure(true)
-            .sameSite("Strict")
+            .sameSite(SAME_SITE_STRICT)
             .path("/")
             .maxAge(0)
             .build();

--- a/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
+++ b/backend/src/main/java/fr/manooweb/backend/api/controller/AuthController.java
@@ -44,4 +44,31 @@ public class AuthController {
 
     return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
   }
+
+  @PostMapping("/logout")
+  @ResponseStatus(HttpStatus.OK)
+  public ResponseEntity<Void> logout() {
+    ResponseCookie authCookie =
+        ResponseCookie.from("auth_token", "")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(0)
+            .build();
+
+    ResponseCookie csrfCookie =
+        ResponseCookie.from("XSRF-TOKEN", "")
+            .httpOnly(false)
+            .secure(true)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(0)
+            .build();
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, authCookie.toString())
+        .header(HttpHeaders.SET_COOKIE, csrfCookie.toString())
+        .build();
+  }
 }

--- a/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
@@ -1,6 +1,7 @@
 package fr.manooweb.backend.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.MvcResult;
 class AuthIntegrationTest {
 
   private static final String AUTH_COOKIE_NAME = "auth_token";
+  private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
 
   @Autowired MockMvc mockMvc;
 
@@ -104,6 +106,49 @@ class AuthIntegrationTest {
         .andExpect(jsonPath("$.roles[0]").value("USER"));
   }
 
+  @Test
+  void logout_withAuthCookieAndCsrf_ShouldDeleteAuthAndCsrfCookies() throws Exception {
+    Cookie authCookie = loginAndGetAuthCookie();
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/v1/auth/logout").cookie(authCookie).with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String authSetCookie = getSetCookie(result, AUTH_COOKIE_NAME);
+    assertThat(authSetCookie)
+        .contains(AUTH_COOKIE_NAME + "=")
+        .contains("Max-Age=0")
+        .contains("Path=/")
+        .contains("HttpOnly")
+        .contains("Secure")
+        .contains("SameSite=Strict");
+
+    String csrfSetCookie = getSetCookie(result, CSRF_COOKIE_NAME);
+    assertThat(csrfSetCookie)
+        .contains(CSRF_COOKIE_NAME + "=")
+        .contains("Max-Age=0")
+        .contains("Path=/")
+        .contains("Secure")
+        .contains("SameSite=Strict")
+        .doesNotContain("HttpOnly");
+  }
+
+  @Test
+  void logout_withoutCsrf_ShouldReturnForbidden() throws Exception {
+    Cookie authCookie = loginAndGetAuthCookie();
+
+    mockMvc
+        .perform(post("/api/v1/auth/logout").cookie(authCookie))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void logout_withoutAuthentication_ShouldReturnForbidden() throws Exception {
+    mockMvc.perform(post("/api/v1/auth/logout").with(csrf())).andExpect(status().isForbidden());
+  }
+
   private Cookie loginAndGetAuthCookie() throws Exception {
     MvcResult result =
         mockMvc
@@ -123,5 +168,12 @@ class AuthIntegrationTest {
     Cookie authCookie = result.getResponse().getCookie(AUTH_COOKIE_NAME);
     assertThat(authCookie).isNotNull();
     return authCookie;
+  }
+
+  private String getSetCookie(MvcResult result, String cookieName) {
+    return result.getResponse().getHeaders(HttpHeaders.SET_COOKIE).stream()
+        .filter(header -> header.startsWith(cookieName + "="))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/bruno/backend/e2e/12_Logout.bru
+++ b/bruno/backend/e2e/12_Logout.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Logout
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/logout
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("status is 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("auth cookie is deleted", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) =>
+      cookie.includes("auth_token=") && cookie.includes("Max-Age=0")
+    );
+    expect(found).to.equal(true);
+  });
+
+  test("csrf cookie is deleted", function () {
+    const setCookies = res.headers["set-cookie"] || [];
+    const found = setCookies.some((cookie) =>
+      cookie.includes("XSRF-TOKEN=") && cookie.includes("Max-Age=0")
+    );
+    expect(found).to.equal(true);
+  });
+}

--- a/bruno/backend/e2e/13_Me after logout (403).bru
+++ b/bruno/backend/e2e/13_Me after logout (403).bru
@@ -1,0 +1,17 @@
+meta {
+  name: Me after logout
+  type: http
+  seq: 16
+}
+
+get {
+  url: {{baseUrl}}/api/v1/me
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("status is 403 after logout", function () {
+    expect(res.status).to.equal(403);
+  });
+}


### PR DESCRIPTION
Closes #118

## Summary

Add logout support to the cookie-based JWT authentication flow.

## Changes

- Add `POST /api/v1/auth/logout`.
- Delete the `auth_token` cookie on logout.
- Delete the `XSRF-TOKEN` cookie on logout.
- Keep logout protected by authentication and CSRF.
- Add backend integration tests for logout success and failure cases.
- Extend Bruno e2e tests with logout and post-logout access validation.

## Security Notes

- Logout clears client-side authentication state by expiring the JWT cookie.
- CSRF protection remains required for logout because authentication is cookie-based.
- The implementation remains stateless: existing JWTs are not server-side revoked.

## Validation

- `./mvnw clean verify`
- `npm run test:api`
- JaCoCo report checked