### PR TITLE
Improve authentication related error messages

### DIFF
--- a/backend/src/main/java/fr/manooweb/backend/api/error/SecurityErrorResponseWriter.java
+++ b/backend/src/main/java/fr/manooweb/backend/api/error/SecurityErrorResponseWriter.java
@@ -1,0 +1,42 @@
+package fr.manooweb.backend.api.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityErrorResponseWriter {
+
+  private final ObjectMapper objectMapper;
+
+  public SecurityErrorResponseWriter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public void write(
+      HttpServletRequest request, HttpServletResponse response, HttpStatus status, String message)
+      throws IOException {
+    if (response.isCommitted()) {
+      return;
+    }
+
+    ApiErrorResponse body =
+        new ApiErrorResponse(
+            OffsetDateTime.now(),
+            status.value(),
+            status.getReasonPhrase(),
+            message,
+            request.getRequestURI(),
+            List.of());
+
+    response.setStatus(status.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    objectMapper.writeValue(response.getWriter(), body);
+  }
+}

--- a/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/manooweb/backend/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package fr.manooweb.backend.config;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
 import fr.manooweb.backend.security.CsrfCookieFilter;
 import fr.manooweb.backend.security.JwtCookieAuthenticationFilter;
+import fr.manooweb.backend.security.RestAccessDeniedHandler;
+import fr.manooweb.backend.security.RestAuthenticationEntryPoint;
 import fr.manooweb.backend.security.SpaCsrfTokenRequestHandler;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
@@ -95,8 +98,9 @@ public class SecurityConfig {
   }
 
   @Bean
-  public JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter(JwtDecoder jwtDecoder) {
-    return new JwtCookieAuthenticationFilter(jwtDecoder);
+  public JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter(
+      JwtDecoder jwtDecoder, SecurityErrorResponseWriter securityErrorResponseWriter) {
+    return new JwtCookieAuthenticationFilter(jwtDecoder, securityErrorResponseWriter);
   }
 
   @Bean
@@ -130,7 +134,9 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter,
-      CsrfCookieFilter csrfCookieFilter)
+      CsrfCookieFilter csrfCookieFilter,
+      RestAuthenticationEntryPoint authenticationEntryPoint,
+      RestAccessDeniedHandler accessDeniedHandler)
       throws Exception {
     http
         // Stateless API: do not create HTTP sessions.
@@ -151,6 +157,13 @@ public class SecurityConfig {
         // Enable HTTP Basic authentication (handy for quick testing).
         // Note: if you access endpoints via browser, Spring may also show a login page.
         .httpBasic(basic -> basic.disable())
+
+        // Return consistent JSON responses for security failures.
+        .exceptionHandling(
+            exceptions ->
+                exceptions
+                    .authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
 
         // Enable cookie-based JWT authentication.
         .addFilterBefore(jwtCookieAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package fr.manooweb.backend.security;
 
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -8,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -24,9 +26,12 @@ public class JwtCookieAuthenticationFilter extends OncePerRequestFilter {
   private static final String AUTH_COOKIE_NAME = "auth_token";
 
   private final JwtDecoder jwtDecoder;
+  private final SecurityErrorResponseWriter responseWriter;
 
-  public JwtCookieAuthenticationFilter(JwtDecoder jwtDecoder) {
+  public JwtCookieAuthenticationFilter(
+      JwtDecoder jwtDecoder, SecurityErrorResponseWriter responseWriter) {
     this.jwtDecoder = jwtDecoder;
+    this.responseWriter = responseWriter;
   }
 
   @Override
@@ -47,6 +52,12 @@ public class JwtCookieAuthenticationFilter extends OncePerRequestFilter {
           SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (JwtException ex) {
           SecurityContextHolder.clearContext();
+          responseWriter.write(
+              request,
+              response,
+              HttpStatus.UNAUTHORIZED,
+              "Invalid or expired authentication token");
+          return;
         }
       }
     }

--- a/backend/src/main/java/fr/manooweb/backend/security/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/RestAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package fr.manooweb.backend.security;
+
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.csrf.CsrfException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final SecurityErrorResponseWriter responseWriter;
+
+  public RestAccessDeniedHandler(SecurityErrorResponseWriter responseWriter) {
+    this.responseWriter = responseWriter;
+  }
+
+  @Override
+  public void handle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException, ServletException {
+    String message =
+        accessDeniedException instanceof CsrfException
+            ? "Invalid or missing CSRF token"
+            : "Access denied";
+
+    responseWriter.write(request, response, HttpStatus.FORBIDDEN, message);
+  }
+}

--- a/backend/src/main/java/fr/manooweb/backend/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/fr/manooweb/backend/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package fr.manooweb.backend.security;
+
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final SecurityErrorResponseWriter responseWriter;
+
+  public RestAuthenticationEntryPoint(SecurityErrorResponseWriter responseWriter) {
+    this.responseWriter = responseWriter;
+  }
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException, ServletException {
+    responseWriter.write(request, response, HttpStatus.UNAUTHORIZED, "Authentication required");
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/AuthIntegrationTest.java
@@ -91,8 +91,25 @@ class AuthIntegrationTest {
   }
 
   @Test
-  void me_withoutAuthentication_ShouldReturnForbidden() throws Exception {
-    mockMvc.perform(get("/api/v1/me")).andExpect(status().isForbidden());
+  void me_withoutAuthentication_ShouldReturnUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error").value("Unauthorized"))
+        .andExpect(jsonPath("$.message").value("Authentication required"))
+        .andExpect(jsonPath("$.path").value("/api/v1/me"));
+  }
+
+  @Test
+  void me_withInvalidJwtCookie_ShouldReturnUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/me").cookie(new Cookie(AUTH_COOKIE_NAME, "invalid-token")))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error").value("Unauthorized"))
+        .andExpect(jsonPath("$.message").value("Invalid or expired authentication token"))
+        .andExpect(jsonPath("$.path").value("/api/v1/me"));
   }
 
   @Test
@@ -141,12 +158,22 @@ class AuthIntegrationTest {
 
     mockMvc
         .perform(post("/api/v1/auth/logout").cookie(authCookie))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.status").value(403))
+        .andExpect(jsonPath("$.error").value("Forbidden"))
+        .andExpect(jsonPath("$.message").value("Invalid or missing CSRF token"))
+        .andExpect(jsonPath("$.path").value("/api/v1/auth/logout"));
   }
 
   @Test
-  void logout_withoutAuthentication_ShouldReturnForbidden() throws Exception {
-    mockMvc.perform(post("/api/v1/auth/logout").with(csrf())).andExpect(status().isForbidden());
+  void logout_withoutAuthentication_ShouldReturnUnauthorized() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/auth/logout").with(csrf()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.error").value("Unauthorized"))
+        .andExpect(jsonPath("$.message").value("Authentication required"))
+        .andExpect(jsonPath("$.path").value("/api/v1/auth/logout"));
   }
 
   private Cookie loginAndGetAuthCookie() throws Exception {

--- a/backend/src/test/java/fr/manooweb/backend/api/error/SecurityErrorResponseWriterTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/api/error/SecurityErrorResponseWriterTest.java
@@ -1,0 +1,44 @@
+package fr.manooweb.backend.api.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class SecurityErrorResponseWriterTest {
+
+  private final SecurityErrorResponseWriter writer =
+      new SecurityErrorResponseWriter(new ObjectMapper().findAndRegisterModules());
+
+  @Test
+  void write_whenResponseIsCommitted_ShouldNotWriteBody() throws IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/me");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    response.setCommitted(true);
+
+    writer.write(request, response, HttpStatus.UNAUTHORIZED, "Authentication required");
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getContentAsString()).isEmpty();
+  }
+
+  @Test
+  void write_whenResponseIsNotCommitted_ShouldWriteApiErrorResponse() throws IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/me");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    writer.write(request, response, HttpStatus.UNAUTHORIZED, "Authentication required");
+
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentType()).isEqualTo("application/json");
+    assertThat(response.getContentAsString())
+        .contains("\"status\":401")
+        .contains("\"error\":\"Unauthorized\"")
+        .contains("\"message\":\"Authentication required\"")
+        .contains("\"path\":\"/api/v1/me\"");
+  }
+}

--- a/backend/src/test/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilterTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/security/JwtCookieAuthenticationFilterTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import java.io.IOException;
@@ -37,7 +39,10 @@ class JwtCookieAuthenticationFilterTest {
   void setUp() {
     SecurityContextHolder.clearContext();
     jwtDecoder = mock(JwtDecoder.class);
-    filter = new JwtCookieAuthenticationFilter(jwtDecoder);
+    filter =
+        new JwtCookieAuthenticationFilter(
+            jwtDecoder,
+            new SecurityErrorResponseWriter(new ObjectMapper().findAndRegisterModules()));
   }
 
   @AfterEach
@@ -84,14 +89,20 @@ class JwtCookieAuthenticationFilterTest {
   }
 
   @Test
-  void doFilterInternal_withInvalidJwt_ShouldClearAuthentication()
+  void doFilterInternal_withInvalidJwt_ShouldReturnUnauthorized()
       throws ServletException, IOException {
     MockHttpServletRequest request = requestWithAuthCookie();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain filterChain = new MockFilterChain();
     when(jwtDecoder.decode(TOKEN_VALUE)).thenThrow(new BadJwtException("Invalid JWT"));
 
-    filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
+    filter.doFilterInternal(request, response, filterChain);
 
     assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentAsString())
+        .contains("\"message\":\"Invalid or expired authentication token\"");
+    assertThat(filterChain.getRequest()).isNull();
     verify(jwtDecoder).decode(TOKEN_VALUE);
   }
 

--- a/backend/src/test/java/fr/manooweb/backend/security/RestAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/fr/manooweb/backend/security/RestAccessDeniedHandlerTest.java
@@ -1,0 +1,52 @@
+package fr.manooweb.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.manooweb.backend.api.error.SecurityErrorResponseWriter;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.security.web.csrf.InvalidCsrfTokenException;
+
+class RestAccessDeniedHandlerTest {
+
+  private final RestAccessDeniedHandler handler =
+      new RestAccessDeniedHandler(
+          new SecurityErrorResponseWriter(new ObjectMapper().findAndRegisterModules()));
+
+  @Test
+  void handle_withCsrfException_ShouldReturnCsrfMessage() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/logout");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    DefaultCsrfToken expectedToken =
+        new DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "expected-token");
+
+    handler.handle(
+        request, response, new InvalidCsrfTokenException(expectedToken, "invalid-token"));
+
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(response.getContentAsString())
+        .contains("\"message\":\"Invalid or missing CSRF token\"");
+  }
+
+  @Test
+  void handle_withGenericAccessDeniedException_ShouldReturnAccessDeniedMessage()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/admin");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    handler.handle(request, response, new AccessDeniedException("Forbidden"));
+
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(response.getContentAsString())
+        .contains("\"error\":\"Forbidden\"")
+        .contains("\"message\":\"Access denied\"")
+        .contains("\"path\":\"/api/v1/admin\"");
+  }
+}

--- a/bruno/backend/e2e/13_Me after logout (401).bru
+++ b/bruno/backend/e2e/13_Me after logout (401).bru
@@ -11,7 +11,7 @@ get {
 }
 
 tests {
-  test("status is 403 after logout", function () {
-    expect(res.status).to.equal(403);
+  test("status is 401 after logout", function () {
+    expect(res.status).to.equal(401);
   });
 }


### PR DESCRIPTION
Closes #119 

## Summary

Improve backend authentication and authorization error responses.

This PR makes Spring Security errors explicit and consistent with the existing API error format:
- return JSON `401 Unauthorized` responses when authentication is missing
- return JSON `401 Unauthorized` responses when the JWT cookie is invalid or expired
- return JSON `403 Forbidden` responses when CSRF validation fails
- return JSON `403 Forbidden` responses for generic access denied cases

## Changes

- Add a shared `SecurityErrorResponseWriter` to serialize security errors as `ApiErrorResponse`.
- Add a custom `RestAuthenticationEntryPoint` for unauthenticated requests.
- Add a custom `RestAccessDeniedHandler` for CSRF and authorization failures.
- Update `JwtCookieAuthenticationFilter` to stop the filter chain and return a clear JSON error when the JWT is invalid.
- Update backend integration and unit tests to cover the new authentication error behavior.
- Update Bruno e2e expectations after logout from `403` to `401`, matching the new unauthenticated semantics.

## Validation

- Backend tests pass.
- Spotless check passes.
- Security error branches are covered, including committed responses, CSRF failures, generic access denied, missing authentication, and invalid JWT cookie.
