### PR TITLE
Handle dynamic page titles

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,26 +6,30 @@ import { legalHtmlResolver } from './legal/resolvers/legal-pages';
 
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'projects' },
-  { path: 'login', component: Login },
+  { path: 'login', component: Login, data: { pageTitleKey: 'auth.login.title' } },
   {
     path: 'projects',
     canActivate: [authGuard],
+    data: { pageTitleKey: 'projects.title.list' },
     loadComponent: () => import('./pages/projects/projects').then((m) => m.Projects),
   },
   {
     path: 'projects/:id',
     canActivate: [authGuard],
+    data: { pageTitleKey: 'projects.title.detail' },
     loadComponent: () =>
       import('./pages/project-detail/project-detail').then((m) => m.ProjectDetail),
   },
   {
     path: 'legal-notice',
     component: LegalPageComponent,
+    data: { pageTitleKey: 'legal.legalNotice.title' },
     resolve: { html: legalHtmlResolver('legalNotice') },
   },
   {
     path: 'privacy-policy',
     component: LegalPageComponent,
+    data: { pageTitleKey: 'legal.privacyPolicy.title' },
     resolve: { html: legalHtmlResolver('privacyPolicy') },
   },
   { path: '**', redirectTo: 'projects' },

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -9,6 +9,7 @@ import { of, throwError } from 'rxjs';
 import { App } from './app';
 import { MatomoService } from './services/matomo';
 import { Auth } from './services/auth';
+import { Title } from '@angular/platform-browser';
 
 @Component({ standalone: true, template: '' })
 class DummyComponent {}
@@ -17,6 +18,7 @@ describe('App', () => {
   let matomoSpy: jasmine.SpyObj<MatomoService>;
   let authSpy: jasmine.SpyObj<Auth>;
   let router: Router;
+  let title: Title;
 
   beforeEach(async () => {
     matomoSpy = jasmine.createSpyObj<MatomoService>('MatomoService', ['trackPageView']);
@@ -28,9 +30,17 @@ describe('App', () => {
       imports: [App],
       providers: [
         provideRouter([
-          { path: 'login', component: DummyComponent },
-          { path: 'projects', component: DummyComponent },
-          { path: 'projects/:id', component: DummyComponent },
+          { path: 'login', component: DummyComponent, data: { pageTitleKey: 'auth.login.title' } },
+          {
+            path: 'projects',
+            component: DummyComponent,
+            data: { pageTitleKey: 'projects.title.list' },
+          },
+          {
+            path: 'projects/:id',
+            component: DummyComponent,
+            data: { pageTitleKey: 'projects.title.detail' },
+          },
         ]),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -41,7 +51,9 @@ describe('App', () => {
     }).compileComponents();
 
     router = TestBed.inject(Router);
+    title = TestBed.inject(Title);
     spyOn(router, 'navigateByUrl').and.callThrough();
+    spyOn(title, 'setTitle');
   });
 
   it('should create the app', () => {
@@ -66,8 +78,23 @@ describe('App', () => {
 
     expect(matomoSpy.trackPageView).toHaveBeenCalledWith(
       `${globalThis.location.origin}/projects`,
-      'Projects – list',
+      'Projects',
     );
+    expect(title.setTitle).toHaveBeenCalledWith('Projects | Project Management App');
+  });
+
+  it('should resolve page title from child route metadata', async () => {
+    const fixture = TestBed.createComponent(App);
+
+    fixture.detectChanges();
+    await router.navigateByUrl('/projects/123');
+    fixture.detectChanges();
+
+    expect(matomoSpy.trackPageView).toHaveBeenCalledWith(
+      `${globalThis.location.origin}/projects/123`,
+      'Project detail',
+    );
+    expect(title.setTitle).toHaveBeenCalledWith('Project detail | Project Management App');
   });
 
   it('should call backend logout and navigate to login when authenticated', () => {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -7,6 +7,7 @@ import { TranslatePipe } from './shared/i18n/translate.pipe';
 import { MatomoService } from './services/matomo';
 import { filter } from 'rxjs';
 import { UiTextService } from './shared/i18n/ui-text.service';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
@@ -26,6 +27,7 @@ export class App implements OnInit {
   readonly auth = inject(Auth);
   readonly matomo = inject(MatomoService);
   readonly translate = inject(UiTextService);
+  private readonly title = inject(Title);
 
   protected readonly copyrightStartYear = 2025;
   protected readonly copyrightEndYear = new Date().getFullYear();
@@ -42,8 +44,11 @@ export class App implements OnInit {
         const path = event.urlAfterRedirects; // ex: /projects/123
         const fullUrl = globalThis.location.origin + path;
 
-        const title = this.getPageTitle(path);
-        this.matomo.trackPageView(fullUrl, title);
+        const pageTitle = this.getCurrentPageTitle();
+        const appTitle = this.translate.t('app.title');
+
+        this.title.setTitle(`${pageTitle} | ${appTitle}`);
+        this.matomo.trackPageView(fullUrl, pageTitle);
       });
   }
 
@@ -61,10 +66,13 @@ export class App implements OnInit {
     }
   }
 
-  private getPageTitle(path: string): string {
-    if (path === '/login') return 'Login';
-    if (path === '/projects') return 'Projects – list';
-    if (path.startsWith('/projects/')) return 'Project – detail';
-    return 'App';
+  private getCurrentPageTitle(): string {
+    let route = this.router.routerState.snapshot.root;
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+
+    const pageTitleKey = route.data['pageTitleKey'] as string | undefined;
+    return pageTitleKey ? this.translate.t(pageTitleKey) : this.translate.t('app.title');
   }
 }

--- a/frontend/src/app/shared/i18n/en/legal.ts
+++ b/frontend/src/app/shared/i18n/en/legal.ts
@@ -4,6 +4,8 @@ export const LEGAL_EN: UiDictionary = {
   'legal.content.unavailable': 'Content unavailable.',
   'legal.legalNotice.filename': 'legal-notice.html',
   'legal.privacyPolicy.filename': 'privacy-policy.html',
+  'legal.legalNotice.title': 'Legal Notice',
+  'legal.privacyPolicy.title': 'Privacy Policy',
   'legal.legalNotice.link.label': 'Legal Notice',
   'legal.privacyPolicy.link.label': 'Privacy Policy',
 };

--- a/frontend/src/app/shared/i18n/en/projects.ts
+++ b/frontend/src/app/shared/i18n/en/projects.ts
@@ -3,6 +3,7 @@ import type { UiDictionary } from '../';
 export const PROJECTS_EN: UiDictionary = {
   // Titles
   'projects.title.list': 'Projects',
+  'projects.title.detail': 'Project detail',
 
   // States
   'projects.state.loading': 'Loading projects…',

--- a/frontend/src/app/shared/i18n/fr/legal.ts
+++ b/frontend/src/app/shared/i18n/fr/legal.ts
@@ -4,6 +4,8 @@ export const LEGAL_FR: UiDictionary = {
   'legal.content.unavailable': 'Aucun contenu disponible.',
   'legal.legalNotice.filename': 'mentions-legales.html',
   'legal.privacyPolicy.filename': 'politique-confidentialite.html',
+  'legal.legalNotice.title': 'Mentions légales',
+  'legal.privacyPolicy.title': 'Politique de confidentialité',
   'legal.legalNotice.link.label': 'Mentions légales',
   'legal.privacyPolicy.link.label': 'Politique de confidentialité',
 };


### PR DESCRIPTION
Closes #82 

## 🎯 Summary

This PR introduces centralized, route-based page title handling for the Angular frontend.

Page titles are now defined through route metadata instead of being hardcoded from URL paths inside the root component.

## ✨ Changes

- Add `data.pageTitleKey` metadata to routed pages.
- Resolve the active route title after navigation.
- Update the browser `<title>` dynamically with Angular `Title`.
- Reuse the same resolved title for Matomo page tracking.
- Add missing i18n title keys for:
  - project detail page;
  - legal notice page;
  - privacy policy page.
- Remove hardcoded path-based title resolution from `App`.

## ✅ Validation

```bash
npm test -- --include 'src/app/app.spec.ts' --include 'src/app/shared/i18n/i18n.spec.ts'
npm run build
