### PR TITLE
Harden loading states

### DIFF
--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -9,6 +9,7 @@ import { MatCardModule } from '@angular/material/card';
 import { UiTextService } from '../../shared/i18n/ui-text.service';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
 import { shouldShowError, focusFirstInvalidControl } from '../../shared/forms/form-helpers';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-login',
@@ -74,15 +75,16 @@ export class Login implements OnInit {
 
     const { email, password } = this.form.getRawValue();
 
-    this.auth.login(email.trim(), password.trim()).subscribe({
-      next: () => {
-        this.loading = false;
-        this.router.navigateByUrl('/projects');
-      },
-      error: () => {
-        this.loading = false;
-        this.error = this.translate.t('auth.login.error.invalidCredentials');
-      },
-    });
+    this.auth
+      .login(email.trim(), password.trim())
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: () => {
+          this.router.navigateByUrl('/projects');
+        },
+        error: () => {
+          this.error = this.translate.t('auth.login.error.invalidCredentials');
+        },
+      });
   }
 }

--- a/frontend/src/app/pages/project-detail/project-detail.spec.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.spec.ts
@@ -92,8 +92,8 @@ describe('ProjectDetail', () => {
     tasksServiceSpy.delete.and.returnValue(of(void 0));
 
     const { component } = createComponent();
-
     spyOn(component, 'loadTasks');
+
     component.openDeleteTaskConfirmDialog(task);
 
     expect(tasksServiceSpy.delete).toHaveBeenCalledWith(task.id);
@@ -108,8 +108,8 @@ describe('ProjectDetail', () => {
     dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, boolean>);
     tasksServiceSpy.delete.and.returnValue(throwError(() => new Error('crash')));
     const { component } = createComponent();
-
     spyOn(component, 'loadTasks');
+
     component.openDeleteTaskConfirmDialog(task);
 
     expect(component.errorTasks).toBe('Failed to delete task');

--- a/frontend/src/app/pages/project-detail/project-detail.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.ts
@@ -15,6 +15,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatCardModule } from '@angular/material/card';
 import { UiTextService } from '../../shared/i18n/ui-text.service';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-project-detail',
@@ -44,8 +45,8 @@ export class ProjectDetail implements OnInit {
 
   project: Project | null = null;
   tasks: Task[] = [];
-  loadingProject = true;
-  loadingTasks = true;
+  loadingProject = false;
+  loadingTasks = false;
   errorProject: string | null = null;
   errorTasks: string | null = null;
   updatingTaskId: string | null = null;
@@ -70,12 +71,11 @@ export class ProjectDetail implements OnInit {
       this.errorTasks = null;
       this.tasksService.create(this.id, result.payload).subscribe({
         next: () => {
-          // refresh list
-          this.loadingTasks = true;
           this.loadTasks();
           this.notify(this.translate.t('tasks.message.created'));
         },
         error: () => {
+          this.loadingTasks = false;
           this.errorTasks = this.translate.t('tasks.message.createFailed');
           this.notify(this.errorTasks);
         },
@@ -99,12 +99,11 @@ export class ProjectDetail implements OnInit {
       this.errorTasks = null;
       this.tasksService.update(result.taskId, result.payload).subscribe({
         next: () => {
-          // refresh list
-          this.loadingTasks = true;
           this.loadTasks();
           this.notify(this.translate.t('tasks.message.updated'));
         },
         error: () => {
+          this.loadingTasks = false;
           this.errorTasks = this.translate.t('tasks.message.updateFailed');
           this.notify(this.errorTasks);
         },
@@ -133,12 +132,11 @@ export class ProjectDetail implements OnInit {
       this.errorTasks = null;
       this.tasksService.delete(task.id).subscribe({
         next: () => {
-          // refresh list
-          this.loadingTasks = true;
           this.loadTasks();
           this.notify(this.translate.t('tasks.message.deleted'));
         },
         error: () => {
+          this.loadingTasks = false;
           this.errorTasks = this.translate.t('tasks.message.deleteFailed');
           this.notify(this.errorTasks);
         },
@@ -152,17 +150,18 @@ export class ProjectDetail implements OnInit {
     this.loadingProject = true;
     this.errorProject = null;
 
-    this.projectsService.getById(this.id).subscribe({
-      next: (project) => {
-        this.project = project;
-        this.loadingProject = false;
-      },
-      error: () => {
-        this.errorProject = this.translate.t('tasks.message.loadProjectFailed');
-        this.loadingProject = false;
-        this.notify(this.errorProject);
-      },
-    });
+    this.projectsService
+      .getById(this.id)
+      .pipe(finalize(() => (this.loadingProject = false)))
+      .subscribe({
+        next: (project) => {
+          this.project = project;
+        },
+        error: () => {
+          this.errorProject = this.translate.t('tasks.message.loadProjectFailed');
+          this.notify(this.errorProject);
+        },
+      });
   }
 
   loadTasks() {
@@ -171,17 +170,18 @@ export class ProjectDetail implements OnInit {
     this.loadingTasks = true;
     this.errorTasks = null;
 
-    this.tasksService.getAll(this.id).subscribe({
-      next: (tasks) => {
-        this.tasks = tasks;
-        this.loadingTasks = false;
-      },
-      error: () => {
-        this.errorTasks = this.translate.t('tasks.message.loadTasksFailed');
-        this.loadingTasks = false;
-        this.notify(this.errorTasks);
-      },
-    });
+    this.tasksService
+      .getAll(this.id)
+      .pipe(finalize(() => (this.loadingTasks = false)))
+      .subscribe({
+        next: (tasks) => {
+          this.tasks = tasks;
+        },
+        error: () => {
+          this.errorTasks = this.translate.t('tasks.message.loadTasksFailed');
+          this.notify(this.errorTasks);
+        },
+      });
   }
 
   ngOnInit() {
@@ -197,18 +197,19 @@ export class ProjectDetail implements OnInit {
     task.status = next;
     this.updatingTaskId = task.id;
 
-    this.tasksService.updateStatus(task.id, next).subscribe({
-      next: () => {
-        this.updatingTaskId = null;
-        this.notify(this.translate.t('tasks.message.statusUpdated'));
-      },
-      error: () => {
-        // rollback
-        task.status = previous;
-        this.updatingTaskId = null;
-        this.notify(this.translate.t('tasks.message.statusUpdateFailed'));
-      },
-    });
+    this.tasksService
+      .updateStatus(task.id, next)
+      .pipe(finalize(() => (this.updatingTaskId = null)))
+      .subscribe({
+        next: () => {
+          this.notify(this.translate.t('tasks.message.statusUpdated'));
+        },
+        error: () => {
+          // rollback
+          task.status = previous;
+          this.notify(this.translate.t('tasks.message.statusUpdateFailed'));
+        },
+      });
   }
 
   nextStatus(current: TaskStatus): TaskStatus {

--- a/frontend/src/app/pages/projects/projects.ts
+++ b/frontend/src/app/pages/projects/projects.ts
@@ -14,6 +14,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatCardModule } from '@angular/material/card';
 import { UiTextService } from '../../shared/i18n/ui-text.service';
 import { TranslatePipe } from '../../shared/i18n/translate.pipe';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-projects',
@@ -53,13 +54,15 @@ export class Projects implements OnInit {
     dialogRef.afterClosed().subscribe((result?: ProjectDialogResult) => {
       if (result?.mode !== 'create') return; // cancel or not create
 
+      this.loading = true;
+      this.error = null;
       this.projectsService.create(result.payload).subscribe({
         next: () => {
-          // refresh list
           this.loadProjects();
           this.notify(this.translate.t('projects.message.created'));
         },
         error: () => {
+          this.loading = false;
           this.error = this.translate.t('projects.message.createFailed');
           this.notify(this.error);
         },
@@ -78,13 +81,15 @@ export class Projects implements OnInit {
     dialogRef.afterClosed().subscribe((result?: ProjectDialogResult) => {
       if (result?.mode !== 'edit' || !result?.id) return; // Only edit expected here
 
+      this.loading = true;
+      this.error = null;
       this.projectsService.update(result.id, result.payload).subscribe({
         next: () => {
-          // refresh list
           this.loadProjects();
           this.notify(this.translate.t('projects.message.updated'));
         },
         error: () => {
+          this.loading = false;
           this.error = this.translate.t('projects.message.updateFailed');
           this.notify(this.error);
         },
@@ -109,13 +114,15 @@ export class Projects implements OnInit {
     dialogRef.afterClosed().subscribe((result?: boolean) => {
       if (result !== true) return; // Cancelled
 
+      this.loading = true;
+      this.error = null;
       this.projectsService.delete(project.id).subscribe({
         next: () => {
-          // refresh list
           this.loadProjects();
           this.notify(this.translate.t('projects.message.deleted'));
         },
         error: () => {
+          this.loading = false;
           this.error = this.translate.t('projects.message.deleteFailed');
           this.notify(this.error);
         },
@@ -127,17 +134,18 @@ export class Projects implements OnInit {
     this.loading = true;
     this.error = null;
 
-    this.projectsService.getAll().subscribe({
-      next: (projects) => {
-        this.projects = projects;
-        this.loading = false;
-      },
-      error: () => {
-        this.error = this.translate.t('projects.message.loadFailed');
-        this.loading = false;
-        this.notify(this.error);
-      },
-    });
+    this.projectsService
+      .getAll()
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (projects) => {
+          this.projects = projects;
+        },
+        error: () => {
+          this.error = this.translate.t('projects.message.loadFailed');
+          this.notify(this.error);
+        },
+      });
   }
 
   showProjectDetail(projectId: string) {


### PR DESCRIPTION
Closes #129 

## 🔧 Summary

Harden frontend loading state handling across authentication, project list, and project detail screens.

## ✅ Changes

- Initialize loading flags to `false` before requests start.
- Use `finalize()` to reliably reset loading state after success or error paths.
- Keep mutation flows explicit when a successful create/update/delete triggers a reload.
- Adjust related component tests to match the refreshed loading behavior.

## 🧪 Validation

- `npm test -- --include 'src/app/pages/login/login.spec.ts' --include 'src/app/pages/projects/projects.spec.ts' --include 'src/app/pages/project-detail/project-detail.spec.ts'`
- `npm run build`
