### PR TITLE
Render multiline descriptions

### DIFF
--- a/frontend/src/app/pages/project-detail/project-detail.html
+++ b/frontend/src/app/pages/project-detail/project-detail.html
@@ -41,7 +41,7 @@
       >
     </mat-card-header>
     <mat-card-content>
-      <p>{{ project?.description }}</p>
+      <p class="multiline-description project-description">{{ project?.description }}</p>
     </mat-card-content>
   </mat-card>
 
@@ -58,11 +58,11 @@
 
   <mat-list class="item-list">
     @for (task of tasks; track task.id; let odd = $odd; let last = $last) {
-      <mat-list-item [class.alt-row]="odd">
+      <mat-list-item [class.alt-row]="odd" [class.description-list-item]="task.description">
         <span matListItemTitle>{{ task.title }}</span>
 
         @if (task.description) {
-          <span matListItemLine>{{ task.description }}</span>
+          <span matListItemLine class="multiline-description">{{ task.description }}</span>
         }
 
         <span matListItemLine class="task-subline">

--- a/frontend/src/app/pages/project-detail/project-detail.scss
+++ b/frontend/src/app/pages/project-detail/project-detail.scss
@@ -29,6 +29,24 @@ mat-list-item.alt-row {
   background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.02));
 }
 
+:host ::ng-deep .item-list .description-list-item.mdc-list-item {
+  height: auto;
+  min-height: 72px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.multiline-description {
+  white-space: pre-line;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.35;
+}
+
+.project-description {
+  margin: 0;
+}
+
 .status-card {
   margin: 0 0 8px 0;
   padding: 0;

--- a/frontend/src/app/pages/project-detail/project-detail.spec.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.spec.ts
@@ -70,6 +70,23 @@ describe('ProjectDetail', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should render multiline project and task descriptions without flattening line breaks', () => {
+    projectsServiceSpy.getById.and.returnValue(
+      of({ ...project, description: 'Project line 1\nProject line 2' }),
+    );
+    tasksServiceSpy.getAll.and.returnValue(
+      of([{ ...task, description: 'Task line 1\nTask line 2' }]),
+    );
+
+    const { fixture } = createComponent();
+    const descriptions = Array.from(
+      fixture.nativeElement.querySelectorAll('.multiline-description'),
+    ) as HTMLElement[];
+
+    expect(descriptions[0].textContent).toContain('Project line 1\nProject line 2');
+    expect(descriptions[1].textContent).toContain('Task line 1\nTask line 2');
+  });
+
   it('should not delete task when confirm dialog is cancelled', () => {
     const dialogRefSpy: Partial<MatDialogRef<unknown, boolean>> = {
       afterClosed: () => of(false),

--- a/frontend/src/app/pages/projects/projects.html
+++ b/frontend/src/app/pages/projects/projects.html
@@ -31,9 +31,9 @@
   <div class="page-content">
     <mat-list class="item-list">
       @for (project of projects; track project.id; let odd = $odd; let last = $last) {
-        <mat-list-item [class.alt-row]="odd">
+        <mat-list-item [class.alt-row]="odd" [class.description-list-item]="project.description">
           <span matListItemTitle>{{ project.name }}</span>
-          <span matListItemLine>{{ project.description }}</span>
+          <span matListItemLine class="multiline-description">{{ project.description }}</span>
 
           <span matListItemMeta class="item-meta">
             <button

--- a/frontend/src/app/pages/projects/projects.scss
+++ b/frontend/src/app/pages/projects/projects.scss
@@ -29,6 +29,20 @@ mat-list-item.alt-row {
   background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.02));
 }
 
+:host ::ng-deep .item-list .description-list-item.mdc-list-item {
+  height: auto;
+  min-height: 72px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.multiline-description {
+  white-space: pre-line;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.35;
+}
+
 .status-card {
   margin: 0 0 8px 0;
   padding: 0;

--- a/frontend/src/app/pages/projects/projects.spec.ts
+++ b/frontend/src/app/pages/projects/projects.spec.ts
@@ -50,6 +50,19 @@ describe('Projects', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should render multiline project descriptions without flattening line breaks', () => {
+    projectsServiceSpy.getAll.and.returnValue(
+      of([{ ...project, description: 'First line\nSecond line' }]),
+    );
+
+    const { fixture } = createComponent();
+    const description = fixture.nativeElement.querySelector(
+      '.multiline-description',
+    ) as HTMLElement;
+
+    expect(description.textContent).toContain('First line\nSecond line');
+  });
+
   it('should not create project when create dialog is closed without create result', () => {
     const dialogRefSpy: Partial<MatDialogRef<unknown, ProjectDialogResult | undefined>> = {
       afterClosed: () => of(undefined),


### PR DESCRIPTION
Closes #130 

## 📝 Summary

Render multiline project and task descriptions correctly in the Angular UI.

## ✅ Changes

- Preserve line breaks visually with `white-space: pre-line`.
- Adjust Material list item layout so multiline descriptions are not clipped.
- Apply the behavior to:
  - project list descriptions
  - project detail description
  - task list descriptions
- Add small DOM checks to ensure multiline descriptions keep line breaks when rendered.

## 🧪 Validation

- `npm test -- --include 'src/app/pages/projects/projects.spec.ts' --include 'src/app/pages/project-detail/project-detail.spec.ts'`
- `npm run build`
