### PR TITLE
Clarify service return types

### DIFF
--- a/frontend/src/app/services/auth.ts
+++ b/frontend/src/app/services/auth.ts
@@ -17,7 +17,7 @@ export class Auth {
   private sessionMessage: SessionMessage | null = null;
   private readonly http = inject(HttpClient);
 
-  login(username: string, password: string) {
+  login(username: string, password: string): Observable<void> {
     return this.http
       .post<void>('/api/v1/auth/login', {
         username,
@@ -32,7 +32,7 @@ export class Auth {
       );
   }
 
-  logout() {
+  logout(): Observable<void> {
     return this.http.post<void>('/api/v1/auth/logout', {}).pipe(
       tap(() => {
         this.clearSession();
@@ -40,13 +40,13 @@ export class Auth {
     );
   }
 
-  clearSession() {
+  clearSession(): void {
     this.authenticated = false;
     this.sessionCheck$ = undefined;
     this.sessionMessage = null;
   }
 
-  expireSession() {
+  expireSession(): void {
     this.authenticated = false;
     this.sessionCheck$ = undefined;
     this.sessionMessage = 'sessionExpired';

--- a/frontend/src/app/services/projects.ts
+++ b/frontend/src/app/services/projects.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 export interface Project {
   id: string;
@@ -16,22 +17,23 @@ export interface CreateProjectRequest {
 export class ProjectsService {
   private readonly http = inject(HttpClient);
 
-  getAll() {
+  getAll(): Observable<Project[]> {
     return this.http.get<Project[]>('/api/v1/projects');
   }
 
-  getById(id: string) {
+  getById(id: string): Observable<Project> {
     return this.http.get<Project>(`/api/v1/projects/${id}`);
   }
 
-  create(payload: CreateProjectRequest) {
+  create(payload: CreateProjectRequest): Observable<Project> {
     return this.http.post<Project>('/api/v1/projects', payload);
   }
 
-  update(id: string, payload: CreateProjectRequest) {
+  update(id: string, payload: CreateProjectRequest): Observable<Project> {
     return this.http.put<Project>(`/api/v1/projects/${id}`, payload);
   }
-  delete(id: string) {
+
+  delete(id: string): Observable<void> {
     return this.http.delete<void>(`/api/v1/projects/${id}`);
   }
 }

--- a/frontend/src/app/services/tasks.ts
+++ b/frontend/src/app/services/tasks.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 export type TaskStatus = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
@@ -25,23 +26,23 @@ export interface CreateTaskRequest {
 export class TasksService {
   private readonly http = inject(HttpClient);
 
-  getAll(projectId: string) {
+  getAll(projectId: string): Observable<Task[]> {
     return this.http.get<Task[]>(`/api/v1/projects/${projectId}/tasks`);
   }
 
-  create(projectId: string, payload: CreateTaskRequest) {
+  create(projectId: string, payload: CreateTaskRequest): Observable<Task> {
     return this.http.post<Task>(`/api/v1/projects/${projectId}/tasks`, payload);
   }
 
-  update(taskId: string, payload: CreateTaskRequest) {
+  update(taskId: string, payload: CreateTaskRequest): Observable<Task> {
     return this.http.put<Task>(`/api/v1/tasks/${taskId}`, payload);
   }
 
-  delete(taskId: string) {
+  delete(taskId: string): Observable<void> {
     return this.http.delete<void>(`/api/v1/tasks/${taskId}`);
   }
 
-  updateStatus(taskId: string, status: TaskStatus) {
+  updateStatus(taskId: string, status: TaskStatus): Observable<Task> {
     return this.http.patch<Task>(`/api/v1/tasks/${taskId}/status`, { status });
   }
 }


### PR DESCRIPTION
Closes #131 

## 🔎 Summary

Clarify Angular service method contracts by making return types explicit.

## ✅ Changes

- Add explicit `Observable<Project[]>`, `Observable<Project>`, and `Observable<void>` return types in `ProjectsService`.
- Add explicit `Observable<Task[]>`, `Observable<Task>`, and `Observable<void>` return types in `TasksService`.
- Add explicit `Observable<void>` return types for auth login/logout flows.
- Add explicit `void` return types for auth session state methods.

## 🎯 Why

This makes service contracts easier to read and prevents ambiguity around methods that return data versus methods that only signal completion, such as `delete()`, `login()`, and `logout()`.

## 🧪 Validation

- `npm test -- --include 'src/app/services/auth.spec.ts' --include 'src/app/services/projects.spec.ts' --include 'src/app/services/tasks.spec.ts' --include 'src/app/services/auth-guard.spec.ts' --include 'src/app/services/auth-interceptor.spec.ts'`
- `npm run build`
