### PR TITLE
Cover loading error paths

### DIFF
--- a/frontend/src/app/pages/project-detail/project-detail.spec.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.spec.ts
@@ -33,6 +33,7 @@ describe('ProjectDetail', () => {
       'create',
       'update',
       'delete',
+      'updateStatus',
     ]);
     dialogSpy = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
     snackBarSpy = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
@@ -343,6 +344,60 @@ describe('ProjectDetail', () => {
       jasmine.anything(),
     );
     expect(component.loadTasks).not.toHaveBeenCalled();
+  });
+
+  it('should return next status for every task status', () => {
+    const { component } = createComponent();
+
+    expect(component.nextStatus('TODO')).toBe('IN_PROGRESS');
+    expect(component.nextStatus('IN_PROGRESS')).toBe('DONE');
+    expect(component.nextStatus('DONE')).toBe('TODO');
+  });
+
+  it('should return translation label for every task status', () => {
+    const { component } = createComponent();
+
+    expect(component.statusLabel('TODO')).toBe('tasks.status.todo');
+    expect(component.statusLabel('IN_PROGRESS')).toBe('tasks.status.inProgress');
+    expect(component.statusLabel('DONE')).toBe('tasks.status.done');
+  });
+
+  it('should return emoji for every task status', () => {
+    const { component } = createComponent();
+
+    expect(component.statusEmoji('TODO')).toBe('📝');
+    expect(component.statusEmoji('IN_PROGRESS')).toBe('⏳');
+    expect(component.statusEmoji('DONE')).toBe('✅');
+  });
+
+  it('should optimistically update task status and reset updating task id on success', () => {
+    tasksServiceSpy.updateStatus.and.returnValue(of({ ...task, status: 'IN_PROGRESS' }));
+    const { component } = createComponent();
+    const updatedTask: Task = { ...task, status: 'TODO' };
+
+    component.onStatusClick(updatedTask);
+
+    expect(updatedTask.status).toBe('IN_PROGRESS');
+    expect(component.updatingTaskId).toBeNull();
+    expect(tasksServiceSpy.updateStatus).toHaveBeenCalledWith(task.id, 'IN_PROGRESS');
+    expect(snackBarSpy.open).toHaveBeenCalledWith('Status updated', 'Close', jasmine.anything());
+  });
+
+  it('should rollback task status and reset updating task id when status update fails', () => {
+    tasksServiceSpy.updateStatus.and.returnValue(throwError(() => new Error('crash')));
+    const { component } = createComponent();
+    const updatedTask: Task = { ...task, status: 'IN_PROGRESS' };
+
+    component.onStatusClick(updatedTask);
+
+    expect(updatedTask.status).toBe('IN_PROGRESS');
+    expect(component.updatingTaskId).toBeNull();
+    expect(tasksServiceSpy.updateStatus).toHaveBeenCalledWith(task.id, 'DONE');
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to update status',
+      'Close',
+      jasmine.anything(),
+    );
   });
 
   function createComponent() {

--- a/frontend/src/app/pages/project-detail/project-detail.spec.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.spec.ts
@@ -400,6 +400,77 @@ describe('ProjectDetail', () => {
     );
   });
 
+  it('should load project and reset project loading state on success', () => {
+    const loadedProject: Project = { ...project, name: 'Loaded project' };
+    projectsServiceSpy.getById.and.returnValue(of(loadedProject));
+
+    const { component } = createComponent();
+
+    expect(component.project).toEqual(loadedProject);
+    expect(component.loadingProject).toBeFalse();
+    expect(component.errorProject).toBeNull();
+    expect(projectsServiceSpy.getById).toHaveBeenCalledWith('p1');
+  });
+
+  it('should reset project loading state and show error when project loading fails', () => {
+    projectsServiceSpy.getById.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+
+    expect(component.loadingProject).toBeFalse();
+    expect(component.errorProject).toBe('Failed to load project');
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to load project',
+      'Close',
+      jasmine.anything(),
+    );
+  });
+
+  it('should not load project when project id is missing', () => {
+    const { component } = createComponent();
+    projectsServiceSpy.getById.calls.reset();
+    component.id = null;
+
+    component.loadProject();
+
+    expect(projectsServiceSpy.getById).not.toHaveBeenCalled();
+  });
+
+  it('should load tasks and reset tasks loading state on success', () => {
+    tasksServiceSpy.getAll.and.returnValue(of([task]));
+
+    const { component } = createComponent();
+
+    expect(component.tasks).toEqual([task]);
+    expect(component.loadingTasks).toBeFalse();
+    expect(component.errorTasks).toBeNull();
+    expect(tasksServiceSpy.getAll).toHaveBeenCalledWith('p1');
+  });
+
+  it('should reset tasks loading state and show error when tasks loading fails', () => {
+    tasksServiceSpy.getAll.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+
+    expect(component.loadingTasks).toBeFalse();
+    expect(component.errorTasks).toBe('Failed to load tasks for this project');
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to load tasks for this project',
+      'Close',
+      jasmine.anything(),
+    );
+  });
+
+  it('should not load tasks when project id is missing', () => {
+    const { component } = createComponent();
+    tasksServiceSpy.getAll.calls.reset();
+    component.id = null;
+
+    component.loadTasks();
+
+    expect(tasksServiceSpy.getAll).not.toHaveBeenCalled();
+  });
+
   function createComponent() {
     const fixture = TestBed.createComponent(ProjectDetail);
     fixture.detectChanges(); // triggers ngOnInit -> loadProject and loadTasks

--- a/frontend/src/app/pages/project-detail/project-detail.spec.ts
+++ b/frontend/src/app/pages/project-detail/project-detail.spec.ts
@@ -87,6 +87,212 @@ describe('ProjectDetail', () => {
     expect(descriptions[1].textContent).toContain('Task line 1\nTask line 2');
   });
 
+  it('should not create task when create dialog is closed without result', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, undefined>> = {
+      afterClosed: () => of(undefined),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, undefined>);
+
+    const { component } = createComponent();
+
+    component.openAddNewTaskDialog();
+
+    expect(tasksServiceSpy.create).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should not create task when project id is missing', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () =>
+        of({
+          mode: 'create',
+          payload: { title: 'Task 2', description: 'Description 2' },
+        }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+
+    const { component } = createComponent();
+    component.id = null;
+
+    component.openAddNewTaskDialog();
+
+    expect(tasksServiceSpy.create).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should not create task when dialog result is not create mode', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () =>
+        of({
+          mode: 'edit',
+          taskId: task.id,
+          payload: { title: 'Task 2', description: 'Description 2' },
+        }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+
+    const { component } = createComponent();
+
+    component.openAddNewTaskDialog();
+
+    expect(tasksServiceSpy.create).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should create task, refresh tasks and open snackbar when create dialog returns create result', () => {
+    const payload = { title: 'Task 2', description: 'Description 2' };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () => of({ mode: 'create', payload }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+    tasksServiceSpy.create.and.returnValue(of({ ...task, ...payload, id: 't2' }));
+
+    const { component } = createComponent();
+    spyOn(component, 'loadTasks');
+
+    component.openAddNewTaskDialog();
+
+    expect(tasksServiceSpy.create).toHaveBeenCalledWith('p1', payload);
+    expect(component.loadTasks).toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith('Task created', 'Close', jasmine.anything());
+  });
+
+  it('should reset loading and show error when task creation fails', () => {
+    const payload = { title: 'Task 2', description: 'Description 2' };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () => of({ mode: 'create', payload }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+    tasksServiceSpy.create.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+    spyOn(component, 'loadTasks');
+
+    component.openAddNewTaskDialog();
+
+    expect(component.loadingTasks).toBeFalse();
+    expect(component.errorTasks).toBe('Failed to create task');
+    expect(tasksServiceSpy.create).toHaveBeenCalledWith('p1', payload);
+    expect(component.loadTasks).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to create task',
+      'Close',
+      jasmine.anything(),
+    );
+  });
+
+  it('should not update task when edit dialog is closed without result', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, undefined>> = {
+      afterClosed: () => of(undefined),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, undefined>);
+
+    const { component } = createComponent();
+
+    component.openEditTaskDialog(task);
+
+    expect(tasksServiceSpy.update).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should not update task when project id is missing', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () =>
+        of({
+          mode: 'edit',
+          taskId: task.id,
+          payload: { title: 'Task updated', description: 'Description updated' },
+        }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+
+    const { component } = createComponent();
+    component.id = null;
+
+    component.openEditTaskDialog(task);
+
+    expect(tasksServiceSpy.update).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should not update task when dialog result is not edit mode', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () =>
+        of({
+          mode: 'create',
+          payload: { title: 'Task updated', description: 'Description updated' },
+        }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+
+    const { component } = createComponent();
+
+    component.openEditTaskDialog(task);
+
+    expect(tasksServiceSpy.update).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should not update task when edit dialog result has no task id', () => {
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () =>
+        of({
+          mode: 'edit',
+          payload: { title: 'Task updated', description: 'Description updated' },
+        }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+
+    const { component } = createComponent();
+
+    component.openEditTaskDialog(task);
+
+    expect(tasksServiceSpy.update).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should update task, refresh tasks and open snackbar when edit dialog returns edit result', () => {
+    const payload = { title: 'Task updated', description: 'Description updated' };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () => of({ mode: 'edit', taskId: task.id, payload }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+    tasksServiceSpy.update.and.returnValue(of({ ...task, ...payload }));
+
+    const { component } = createComponent();
+    spyOn(component, 'loadTasks');
+
+    component.openEditTaskDialog(task);
+
+    expect(tasksServiceSpy.update).toHaveBeenCalledWith(task.id, payload);
+    expect(component.loadTasks).toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith('Task updated', 'Close', jasmine.anything());
+  });
+
+  it('should reset loading and show error when task update fails', () => {
+    const payload = { title: 'Task updated', description: 'Description updated' };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, unknown>> = {
+      afterClosed: () => of({ mode: 'edit', taskId: task.id, payload }),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, unknown>);
+    tasksServiceSpy.update.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+    spyOn(component, 'loadTasks');
+
+    component.openEditTaskDialog(task);
+
+    expect(component.loadingTasks).toBeFalse();
+    expect(component.errorTasks).toBe('Failed to update task');
+    expect(tasksServiceSpy.update).toHaveBeenCalledWith(task.id, payload);
+    expect(component.loadTasks).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to update task',
+      'Close',
+      jasmine.anything(),
+    );
+  });
+
   it('should not delete task when confirm dialog is cancelled', () => {
     const dialogRefSpy: Partial<MatDialogRef<unknown, boolean>> = {
       afterClosed: () => of(false),

--- a/frontend/src/app/pages/projects/projects.spec.ts
+++ b/frontend/src/app/pages/projects/projects.spec.ts
@@ -100,6 +100,33 @@ describe('Projects', () => {
     expect(snackBarSpy.open).toHaveBeenCalledWith('Project created', 'Close', jasmine.anything());
   });
 
+  it('should reset loading and show error when project creation fails', () => {
+    const dialogResult: ProjectDialogResult = {
+      mode: 'create',
+      payload: { name: 'Project 2', description: 'Description 2' },
+    };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, ProjectDialogResult>> = {
+      afterClosed: () => of(dialogResult),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, ProjectDialogResult>);
+    projectsServiceSpy.create.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+
+    spyOn(component, 'loadProjects');
+    component.openAddNewProjectDialog();
+
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('Failed to create project');
+    expect(projectsServiceSpy.create).toHaveBeenCalledWith(dialogResult.payload);
+    expect(component.loadProjects).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to create project',
+      'Close',
+      jasmine.anything(),
+    );
+  });
+
   it('should not update project when edit dialog is closed without valid edit result', () => {
     const dialogRefSpy: Partial<MatDialogRef<unknown, ProjectDialogResult | undefined>> = {
       afterClosed: () => of(undefined),
@@ -136,6 +163,34 @@ describe('Projects', () => {
     expect(projectsServiceSpy.update).toHaveBeenCalledWith(dialogResult.id!, dialogResult.payload);
     expect(component.loadProjects).toHaveBeenCalled();
     expect(snackBarSpy.open).toHaveBeenCalledWith('Project updated', 'Close', jasmine.anything());
+  });
+
+  it('should reset loading and show error when project update fails', () => {
+    const dialogResult: ProjectDialogResult = {
+      mode: 'edit',
+      id: project.id,
+      payload: { name: 'Project 1 updated', description: 'Description updated' },
+    };
+    const dialogRefSpy: Partial<MatDialogRef<unknown, ProjectDialogResult>> = {
+      afterClosed: () => of(dialogResult),
+    };
+    dialogSpy.open.and.returnValue(dialogRefSpy as MatDialogRef<unknown, ProjectDialogResult>);
+    projectsServiceSpy.update.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+
+    spyOn(component, 'loadProjects');
+    component.openEditProjectDialog(project);
+
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('Failed to update project');
+    expect(projectsServiceSpy.update).toHaveBeenCalledWith(dialogResult.id!, dialogResult.payload);
+    expect(component.loadProjects).not.toHaveBeenCalled();
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to update project',
+      'Close',
+      jasmine.anything(),
+    );
   });
 
   it('should not delete project when confirm dialog is cancelled', () => {
@@ -188,6 +243,20 @@ describe('Projects', () => {
       jasmine.anything(),
     );
     expect(component.loadProjects).not.toHaveBeenCalled();
+  });
+
+  it('should reset loading and show error when projects loading fails', () => {
+    projectsServiceSpy.getAll.and.returnValue(throwError(() => new Error('crash')));
+
+    const { component } = createComponent();
+
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('Failed to load projects');
+    expect(snackBarSpy.open).toHaveBeenCalledWith(
+      'Failed to load projects',
+      'Close',
+      jasmine.anything(),
+    );
   });
 });
 


### PR DESCRIPTION
## 🧪 Summary

Improve frontend test coverage for loading and error handling paths introduced during the US#15 frontend refactor.

## ✅ Changes

- Add coverage for `Projects` error paths:
  - project creation failure
  - project update failure
  - project list loading failure
- Add coverage for `ProjectDetail` task dialog flows:
  - create/edit dialog cancellation
  - invalid dialog result modes
  - missing project id
  - missing task id on edit
  - create/update success and failure paths
- Add coverage for task status behavior:
  - full status cycle: `TODO → IN_PROGRESS → DONE → TODO`
  - status labels
  - status emojis
  - optimistic update success
  - rollback on update failure
- Add coverage for project detail loading paths:
  - project loading success/error
  - task loading success/error
  - early return when project id is missing

## 🎯 Why

These tests cover the frontend branches added while hardening loading states and error handling, especially the paths reported as uncovered by SonarCloud.

## 🧪 Validation

- `npm test -- --include 'src/app/pages/projects/projects.spec.ts'`
- `npm test -- --include 'src/app/pages/project-detail/project-detail.spec.ts'`