### PR TITLE
Migrate backend to java 25

### DIFF
--- a/.github/workflows/api-e2e-bruno.yml
+++ b/.github/workflows/api-e2e-bruno.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Set up Node 20

--- a/.github/workflows/backend-sonarqube.yml
+++ b/.github/workflows/backend-sonarqube.yml
@@ -15,11 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Build backend (for analysis)

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,11 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Build & verify backend

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 **Fullstack demo project** built with a modern Java / Angular stack.
 
-- **Backend**: Spring Boot 3 (Java 21), PostgreSQL, Flyway, Spring Security, JWT
+- **Backend**: Spring Boot 3 (Java 25), PostgreSQL, Flyway, Spring Security, JWT
 - **Frontend**: Angular 20 + Angular Material (standalone components only)
 - **API documentation**: OpenAPI / Swagger
 - **API tests**: Bruno (manual + E2E in CI)
@@ -131,7 +131,7 @@ flowchart LR
 
 ### Prerequisites
 
-- Java 21
+- Java 25
 - Node.js + npm
 - Docker + Docker Compose
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-21 AS build
+FROM maven:3.9.12-eclipse-temurin-25 AS build
 
 WORKDIR /build
 
@@ -9,7 +9,7 @@ COPY src/ src/
 RUN chmod +x mvnw
 RUN ./mvnw clean package -DskipTests
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 
 WORKDIR /app
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,7 +30,8 @@
 	<properties>
 		<java.version>21</java.version>
 		<jjwt.version>0.12.6</jjwt.version>
-		<spotless.version>2.43.0</spotless.version>
+		<spotless.version>3.4.0</spotless.version>
+		<google-java-format.version>1.34.1</google-java-format.version>
 		<jacoco.version>0.8.14</jacoco.version>
 	</properties>
 	<dependencies>
@@ -133,7 +134,9 @@
 				<version>${spotless.version}</version>
 				<configuration>
 					<java>
-						<googleJavaFormat/>
+						<googleJavaFormat>
+							<version>${google-java-format.version}</version>
+						</googleJavaFormat>
 						<removeUnusedImports/>
 						<trimTrailingWhitespace/>
 						<endWithNewline/>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,6 +33,7 @@
 		<spotless.version>3.4.0</spotless.version>
 		<google-java-format.version>1.34.1</google-java-format.version>
 		<jacoco.version>0.8.14</jacoco.version>
+		<argLine/>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -127,6 +128,24 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,7 +31,7 @@
 		<java.version>21</java.version>
 		<jjwt.version>0.12.6</jjwt.version>
 		<spotless.version>2.43.0</spotless.version>
-		<jacoco.version>0.8.11</jacoco.version>
+		<jacoco.version>0.8.14</jacoco.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,7 +28,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 		<jjwt.version>0.12.6</jjwt.version>
 		<spotless.version>3.4.0</spotless.version>
 		<google-java-format.version>1.34.1</google-java-format.version>


### PR DESCRIPTION
## ☕ Java 25 backend migration

This PR migrates the backend runtime and build toolchain from Java 21 to Java 25.

## ✅ Changes

- Update backend Maven configuration to compile with Java 25
- Update JaCoCo to support Java 25 bytecode coverage
- Update Spotless and explicitly configure `google-java-format`
- Configure Mockito as a Java agent for tests
- Update backend Docker build and runtime images to Temurin 25
- Update GitHub Actions backend workflows to use Java 25
- Update README prerequisites and backend stack documentation

## 🧪 Validation

- `./mvnw clean verify`
- Backend tests pass locally
- Docker backend image builds successfully with Java 25
- Docker runtime image uses Temurin 25
- No remaining Java 21 references in backend/CI documentation paths

## ⚠️ Notes

- Spotless emits a known JDK 25 warning related to internal `sun.misc.Unsafe` usage in `spotless-lib`.
This is tracked upstream: https://github.com/diffplug/spotless/issues/2808
- The warning is non-blocking and does not affect build success.
- It is left as-is for now because it likely requires an upstream tooling update.
